### PR TITLE
Use default security options for libp2p node

### DIFF
--- a/client/engine/messageservice/p2p-message-service/service.go
+++ b/client/engine/messageservice/p2p-message-service/service.go
@@ -84,7 +84,7 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 		libp2p.Identity(messageKey),
 		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port)),
 		libp2p.Transport(tcp.NewTCPTransport),
-		libp2p.NoSecurity,
+		// libp2p.NoSecurity, // Use default security options (Noise + TLS)
 		libp2p.DefaultMuxers,
 	}
 	host, err := libp2p.New(options...)
@@ -105,6 +105,9 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 		ms.receivePeerInfo(stream)
 		stream.Close()
 	})
+
+	fmt.Println("P2PMessageService started with Peer Id:", ms.p2pHost.ID())
+	fmt.Println("Address:", ms.me.Hex())
 
 	return ms
 }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386