### PR TITLE
Add websocket transport in message service to connect with browser client

### DIFF
--- a/client/engine/messageservice/p2p-message-service/service.go
+++ b/client/engine/messageservice/p2p-message-service/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	"github.com/libp2p/go-libp2p/p2p/transport/websocket"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/rs/zerolog"
 	"github.com/statechannels/go-nitro/internal/logging"
@@ -64,7 +65,7 @@ func (ms *P2PMessageService) Id() peer.ID {
 // NewMessageService returns a running P2PMessageService listening on the given ip, port and message key.
 // If useMdnsPeerDiscovery is true, the message service will use mDNS to discover peers.
 // Otherwise, peers must be added manually via `AddPeers`.
-func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdnsPeerDiscovery bool, logWriter io.Writer) *P2PMessageService {
+func NewMessageService(ip string, tcpPort int, wsPort int, me types.Address, pk []byte, useMdnsPeerDiscovery bool, logWriter io.Writer) *P2PMessageService {
 	logging.ConfigureZeroLogger()
 
 	ms := &P2PMessageService{
@@ -82,8 +83,12 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 
 	options := []libp2p.Option{
 		libp2p.Identity(messageKey),
-		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port)),
+		libp2p.ListenAddrStrings(
+			fmt.Sprintf("/ip4/%s/tcp/%d", ip, tcpPort),
+			fmt.Sprintf("/ip4/%s/tcp/%d/ws", ip, wsPort),
+		),
 		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Transport(websocket.New),
 		// libp2p.NoSecurity, // Use default security options (Noise + TLS)
 		libp2p.DefaultMuxers,
 	}

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -77,6 +77,7 @@ func setupMessageService(tc TestCase, tp TestParticipant, si sharedTestInfrastru
 		ms := p2pms.NewMessageService(
 			"127.0.0.1",
 			int(tp.Port),
+			int(tp.WSPort),
 			tp.Address(),
 			tp.PrivateKey,
 			true,

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -60,9 +60,9 @@ func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 	chainServiceB := chainservice.NewMockChainService(chain, ta.Bob.Address())
 	chainServiceI := chainservice.NewMockChainService(chain, ta.Irene.Address())
 
-	rpcClientA, msgA, cleanupFnA := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3005, 4005, chainServiceA, logDestination, connectionType)
-	rpcClientB, msgB, cleanupFnB := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3006, 4006, chainServiceB, logDestination, connectionType)
-	rpcClientI, msgI, cleanupFnC := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3007, 4007, chainServiceI, logDestination, connectionType)
+	rpcClientA, msgA, cleanupFnA := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3005, 5005, 4005, chainServiceA, logDestination, connectionType)
+	rpcClientB, msgB, cleanupFnB := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3006, 5006, 4006, chainServiceB, logDestination, connectionType)
+	rpcClientI, msgI, cleanupFnC := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3007, 5007, 4007, chainServiceI, logDestination, connectionType)
 	waitForPeerInfoExchange(2, msgA, msgB, msgI)
 	defer cleanupFnA()
 	defer cleanupFnB()
@@ -185,6 +185,7 @@ func setupNitroNodeWithRPCClient(
 	t *testing.T,
 	pk []byte,
 	msgPort int,
+	wsMsgPort int,
 	rpcPort int,
 	chain *chainservice.MockChainService,
 	logDestination *os.File,
@@ -192,6 +193,7 @@ func setupNitroNodeWithRPCClient(
 ) (*rpc.RpcClient, *p2pms.P2PMessageService, func()) {
 	messageservice := p2pms.NewMessageService("127.0.0.1",
 		msgPort,
+		wsMsgPort,
 		crypto.GetAddressFromSecretKeyBytes(pk),
 		pk,
 		true,

--- a/internal/testactors/actors.go
+++ b/internal/testactors/actors.go
@@ -14,6 +14,7 @@ type Actor struct {
 	Role       uint
 	Name       ActorName
 	Port       uint
+	WSPort     uint
 }
 
 func (a Actor) Destination() types.Destination {
@@ -24,7 +25,10 @@ func (a Actor) Address() types.Address {
 	return crypto.GetAddressFromSecretKeyBytes(a.PrivateKey)
 }
 
-const START_PORT = 3200
+const (
+	START_PORT    = 3200
+	WS_START_PORT = 5200
+)
 
 // Alice has the address 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE
 var Alice Actor = Actor{
@@ -32,6 +36,7 @@ var Alice Actor = Actor{
 	0,
 	"alice",
 	START_PORT + 0,
+	WS_START_PORT + 0,
 }
 
 // Bob has the address 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
@@ -40,6 +45,7 @@ var Bob Actor = Actor{
 	2,
 	"bob",
 	START_PORT + 1,
+	WS_START_PORT + 1,
 }
 
 // Brian has the address 0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01
@@ -48,6 +54,7 @@ var Brian Actor = Actor{
 	2,
 	"brian",
 	START_PORT + 2,
+	WS_START_PORT + 2,
 }
 
 // Irene has the address 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db
@@ -56,4 +63,5 @@ var Irene Actor = Actor{
 	1,
 	"irene",
 	START_PORT + 3,
+	WS_START_PORT + 3,
 }

--- a/main.go
+++ b/main.go
@@ -36,10 +36,11 @@ func main() {
 		VPA_ADDRESS       = "vpaaddress"
 		CA_ADDRESS        = "caaddress"
 		MSG_PORT          = "msgport"
+		WS_MSG_PORT       = "wsmsgport"
 		RPC_PORT          = "rpcport"
 	)
 	var pkString, chainUrl, naAddress, vpaAddress, caAddress, chainPk string
-	var msgPort, rpcPort int
+	var msgPort, wsMsgPort, rpcPort int
 	var useNats, useDurableStore bool
 
 	flags := []cli.Flag{
@@ -110,6 +111,13 @@ func main() {
 			Destination: &msgPort,
 		}),
 		altsrc.NewIntFlag(&cli.IntFlag{
+			Name:        WS_MSG_PORT,
+			Usage:       "Specifies the websocket port for the message service.",
+			Value:       5005,
+			Category:    "Connectivity:",
+			Destination: &wsMsgPort,
+		}),
+		altsrc.NewIntFlag(&cli.IntFlag{
 			Name:        RPC_PORT,
 			Usage:       "Specifies the tcp port for the rpc server.",
 			Value:       4005,
@@ -157,8 +165,8 @@ func main() {
 				panic(err)
 			}
 
-			fmt.Println("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
-			messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, true, logDestination)
+			fmt.Println("Initializing message service on tcp port " + fmt.Sprint(msgPort) + " and websocket port " + fmt.Sprint(wsMsgPort) + "...")
+			messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, wsMsgPort, *ourStore.GetAddress(), pk, true, logDestination)
 			node := client.New(
 				messageservice,
 				chainService,

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ Usage of ./nitro-rpc-server:
         Specifies whether to deploy the adjudicator and create2deployer contracts.
   -msgport int
         Specifies the tcp port for the  message service. (default 3005)
+  -wsmsgport int
+        Specifies the websocket port for the  message service. (default 5005)
   -naaddress string
         Specifies the address of the nitro adjudicator contract. Default is the address computed by the Create2Deployer contract. (default "0xC6A55E07566416274dBF020b5548eecEdB56290c")
   -pk string

--- a/scripts/test-configs/alice.toml
+++ b/scripts/test-configs/alice.toml
@@ -3,6 +3,7 @@
 usedurablestore = true
 
 msgport = 3005
+wsmsgport = 5005
 rpcport = 4005
 
 pk = "2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d"

--- a/scripts/test-configs/bob.toml
+++ b/scripts/test-configs/bob.toml
@@ -3,6 +3,7 @@
 usedurablestore = true
 
 msgport = 3007
+wsmsgport = 5007
 rpcport = 4007
 
 pk = "0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4"

--- a/scripts/test-configs/irene.toml
+++ b/scripts/test-configs/irene.toml
@@ -3,6 +3,7 @@
 usedurablestore = true
 
 msgport = 3006
+wsmsgport = 5006
 rpcport = 4006
 
 pk = "febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781"


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Add websocket transport in libp2p options
- Add CLI argument to pass port number for websocket