### PR TITLE
Use Node version 18.15 for publishing package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,21 +5,18 @@ on:
 jobs:
   npm_publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 18.x ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+        # https://github.com/NomicFoundation/hardhat/issues/3877
+      - name: Use Node.js 18.15
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "18.15.0"
       - name: "Install dependencies and build packages"
         run: |
           cd ./nitro-protocol
-          npm install --legacy-peer-deps
-          npm run build:typescript
+          npm ci --legacy-peer-deps
       - name: Configure git.vdb.to npm registry
         run: |
           npm config set registry https://git.vdb.to/api/packages/cerc-io/npm/

--- a/nitro-protocol/package-lock.json
+++ b/nitro-protocol/package-lock.json
@@ -5071,7 +5071,6 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
       "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -5090,7 +5089,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
       "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -5399,7 +5397,7 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "deprecated": "core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.",
       "dev": true,
       "hasInstallScript": true
     },
@@ -5407,7 +5405,6 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
       "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-      "deprecated": "core-js-pure@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js-pure.",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -5532,7 +5529,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -5972,7 +5968,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
       "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
       "dependencies": {
         "ethereum-common": "^0.0.18",
@@ -6080,7 +6075,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.0.1",
@@ -6100,7 +6094,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
       "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
       "dependencies": {
         "ethereum-common": "^0.0.18",
@@ -6126,7 +6119,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
       "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/vm. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.1.2",
@@ -6146,7 +6138,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
       "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.0.1",
@@ -6175,7 +6166,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
       "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
@@ -6398,7 +6388,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.3.0.tgz",
       "integrity": "sha512-ugD1AvaggvKaZDgnS19W5qOfepjGc7qHrt7TrAaL54gJw9SHvgIXJ3r2xOMW30RWJZNP+1GlTOy5oye7yXA4xA==",
-      "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
       "dev": true,
       "dependencies": {
         "buffer": "^5.2.1",
@@ -6498,7 +6487,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.0.1",
@@ -6518,7 +6506,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
       "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
       "dependencies": {
         "ethereum-common": "^0.0.18",
@@ -6544,7 +6531,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
       "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/vm. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.1.2",
@@ -6564,7 +6550,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
       "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.0.1",
@@ -6593,7 +6578,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
       "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
@@ -6791,7 +6775,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
       "integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/ethash. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.1.2",
@@ -6892,7 +6875,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
       "integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
-      "deprecated": "Please use Util.Account class found on package ethereumjs-util@^7.0.6 https://github.com/ethereumjs/ethereumjs-util/releases/tag/v7.0.6",
       "dev": true,
       "dependencies": {
         "ethereumjs-util": "^6.0.0",
@@ -6904,7 +6886,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
       "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.0.1",
@@ -7123,7 +7104,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
       "integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
-      "deprecated": "New package name format for new versions: @ethereumjs/blockchain. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.6.1",
@@ -7142,14 +7122,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
       "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ==",
-      "deprecated": "New package name format for new versions: @ethereumjs/common. Please update.",
       "dev": true
     },
     "node_modules/@statechannels/devtools/node_modules/ganache-core/node_modules/ethereumjs-tx": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
       "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
@@ -7175,7 +7153,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
       "integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/vm. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.1.2",
@@ -9557,7 +9534,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
       "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -9569,7 +9545,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
       "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
-      "deprecated": "This module has been superseded by the multiformats module",
+      "deprecated": "stable api reached",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -9592,7 +9568,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
       "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -10781,7 +10756,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
       "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
-      "deprecated": "Renamed to @metamask/safe-event-emitter",
       "dev": true,
       "dependencies": {
         "events": "^3.0.0"
@@ -11247,7 +11221,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -11280,7 +11253,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
     "node_modules/@statechannels/devtools/node_modules/ganache-core/node_modules/split-string": {
@@ -12230,7 +12202,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -12493,7 +12464,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "optional": true,
       "bin": {
@@ -12646,7 +12616,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
-      "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
       "dev": true,
       "dependencies": {
         "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
@@ -12656,7 +12625,6 @@
     "node_modules/@statechannels/devtools/node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-abi": {
       "version": "0.6.8",
       "resolved": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
-      "integrity": "sha512-sfpG4fyD67Iu4ENpq+Am9ZxMVrArLiMaBFMg7AQnPZg5AwG5UCy1J72o0Z6hXzX5+DPsZTniH6Sw86QWYrFeVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12694,7 +12662,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.0.1",
@@ -12714,7 +12681,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
       "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
       "dependencies": {
         "ethereum-common": "^0.0.18",
@@ -12740,7 +12706,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
       "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/vm. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.1.2",
@@ -12760,7 +12725,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
       "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
       "dependencies": {
         "async": "^2.0.1",
@@ -12789,7 +12753,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
       "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
@@ -15328,7 +15291,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
       "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -19746,9 +19709,8 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/abi": {
       "version": "5.0.0-beta.153",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
-      "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/address": ">=5.0.0-beta.128",
@@ -19764,8 +19726,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/abstract-provider": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
-      "integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
       "dev": true,
       "funding": [
         {
@@ -19777,6 +19737,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.0.13",
@@ -19790,8 +19751,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/abstract-signer": {
       "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.10.tgz",
-      "integrity": "sha512-irx7kH7FDAeW7QChDPW19WsxqeB1d3XLyOLSXm0bfPqL1SS07LXWltBJUBUxqC03ORpAOcM3JQj57DU8JnVY2g==",
       "dev": true,
       "funding": [
         {
@@ -19803,6 +19762,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.0.8",
@@ -19814,8 +19774,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/address": {
       "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
-      "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
       "dev": true,
       "funding": [
         {
@@ -19827,6 +19785,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.0.13",
@@ -19838,8 +19797,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/base64": {
       "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
-      "integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
       "dev": true,
       "funding": [
         {
@@ -19851,6 +19808,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.0.9"
@@ -19858,8 +19816,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/bignumber": {
       "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
-      "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
       "dev": true,
       "funding": [
         {
@@ -19871,6 +19827,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.0.9",
@@ -19880,8 +19837,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/bytes": {
       "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
-      "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
       "dev": true,
       "funding": [
         {
@@ -19893,6 +19848,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/logger": "^5.0.8"
@@ -19900,8 +19856,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/constants": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
-      "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
       "dev": true,
       "funding": [
         {
@@ -19913,6 +19867,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.0.13"
@@ -19920,8 +19875,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/hash": {
       "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
-      "integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
       "dev": true,
       "funding": [
         {
@@ -19933,6 +19886,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.0.10",
@@ -19947,8 +19901,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/keccak256": {
       "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
-      "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
       "dev": true,
       "funding": [
         {
@@ -19960,6 +19912,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.0.9",
@@ -19968,8 +19921,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/logger": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-      "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
       "dev": true,
       "funding": [
         {
@@ -19981,12 +19932,11 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/@ethersproject/networks": {
       "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
-      "integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
       "dev": true,
       "funding": [
         {
@@ -19998,6 +19948,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/logger": "^5.0.8"
@@ -20005,8 +19956,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/properties": {
       "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
-      "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
       "dev": true,
       "funding": [
         {
@@ -20018,6 +19967,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/logger": "^5.0.8"
@@ -20025,8 +19975,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/rlp": {
       "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
-      "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
       "dev": true,
       "funding": [
         {
@@ -20038,6 +19986,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.0.9",
@@ -20046,8 +19995,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/signing-key": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
-      "integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
       "dev": true,
       "funding": [
         {
@@ -20059,6 +20006,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.0.9",
@@ -20069,8 +20017,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/strings": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
-      "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
       "dev": true,
       "funding": [
         {
@@ -20082,6 +20028,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.0.9",
@@ -20091,8 +20038,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/transactions": {
       "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
-      "integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
       "dev": true,
       "funding": [
         {
@@ -20104,6 +20049,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/address": "^5.0.9",
@@ -20119,8 +20065,6 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/web": {
       "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
-      "integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
       "dev": true,
       "funding": [
         {
@@ -20132,6 +20076,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@ethersproject/base64": "^5.0.7",
@@ -20143,9 +20088,8 @@
     },
     "node_modules/ganache-core/node_modules/@sindresorhus/is": {
       "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=6"
@@ -20153,9 +20097,8 @@
     },
     "node_modules/ganache-core/node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "defer-to-connect": "^1.0.1"
@@ -20166,48 +20109,42 @@
     },
     "node_modules/ganache-core/node_modules/@types/bn.js": {
       "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/ganache-core/node_modules/@types/node": {
       "version": "14.14.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/@types/pbkdf2": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/ganache-core/node_modules/@types/secp256k1": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-      "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/ganache-core/node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/ganache-core/node_modules/abstract-leveldown": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
-      "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       },
@@ -20217,9 +20154,8 @@
     },
     "node_modules/ganache-core/node_modules/accepts": {
       "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "mime-types": "~2.1.24",
@@ -20231,16 +20167,14 @@
     },
     "node_modules/ganache-core/node_modules/aes-js": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -20254,9 +20188,8 @@
     },
     "node_modules/ganache-core/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -20266,61 +20199,54 @@
     },
     "node_modules/ganache-core/node_modules/arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/arr-union": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/array-unique": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/asn1": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
     },
     "node_modules/ganache-core/node_modules/asn1.js": {
       "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "^4.0.0",
@@ -20331,57 +20257,50 @@
     },
     "node_modules/ganache-core/node_modules/assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
     },
     "node_modules/ganache-core/node_modules/assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/async": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.11"
       }
     },
     "node_modules/ganache-core/node_modules/async-eventemitter": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
-      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async": "^2.4.0"
       }
     },
     "node_modules/ganache-core/node_modules/async-limiter": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/atob": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true,
+      "license": "(MIT OR Apache-2.0)",
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -20391,24 +20310,21 @@
     },
     "node_modules/ganache-core/node_modules/aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/ganache-core/node_modules/aws4": {
       "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -20417,27 +20333,24 @@
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -20451,15 +20364,13 @@
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -20469,18 +20380,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/supports-color": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-core": {
       "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "babel-generator": "^6.26.0",
@@ -20505,42 +20414,37 @@
     },
     "node_modules/ganache-core/node_modules/babel-core/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-core/node_modules/json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       }
     },
     "node_modules/ganache-core/node_modules/babel-core/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-core/node_modules/slash": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-generator": {
       "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-messages": "^6.23.0",
         "babel-runtime": "^6.26.0",
@@ -20554,18 +20458,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-generator/node_modules/jsesc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha512-Mke0DA0QjUWuJlhsE0ZPPhYiJkRap642SmI/4ztCFaUs6V2AiH1sfecc+57NgaryfAA2VR3v6O+CSjC1jZJKOA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       }
     },
     "node_modules/ganache-core/node_modules/babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha512-gCtfYORSG1fUMX4kKraymq607FWgMWg+j42IFPc18kFQEsmtaibP4UrqsXt8FlEJle25HUd4tsoDR7H2wDhe9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-explode-assignable-expression": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20574,9 +20476,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-call-delegate": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha512-RL8n2NiEj+kKztlrVJM9JT1cXzzAdvWFh76xh/H1I4nKwunzE4INBXn8ieCZ+wh4zWszZk7NBS1s/8HR5jDkzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-hoist-variables": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20586,9 +20487,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-define-map": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha512-bHkmjcC9lM1kmZcVpA5t2om2nzT/xiZpo6TJq7UlZ3wqKfzia4veeXbIhKvJXAMzhhEBd3cR1IElL5AenWEUpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.26.0",
@@ -20598,9 +20498,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha512-qe5csbhbvq6ccry9G7tkXbzNtcDiH4r51rrPUbwwoTzZ18AqxWYRZT6AOmxrpxKnQBW0pYlBI/8vh73Z//78nQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-traverse": "^6.24.1",
@@ -20609,9 +20508,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-function-name": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha512-Oo6+e2iX+o9eVvJ9Y5eKL5iryeRdsIkwRYheCuhYdVHsdEQysbc2z2QkqCLIYnNxkT5Ss3ggrHdXiDI7Dhrn4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-get-function-arity": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20622,9 +20520,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-get-function-arity": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha512-WfgKFX6swFB1jS2vo+DwivRN4NB8XUdM3ij0Y1gnC21y1tdBoe6xjVnd7NSI6alv+gZXCtJqvrTeMW3fR/c0ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -20632,9 +20529,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-hoist-variables": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha512-zAYl3tqerLItvG5cKYw7f1SpvIxS9zi7ohyGHaI9cgDUjAT6YcY9jIEH5CstetP5wHIVSceXwNS7Z5BpJg+rOw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -20642,9 +20538,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-optimise-call-expression": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha512-Op9IhEaxhbRT8MDXx2iNuMgciu2V8lDvYCNQbDGjdBNCjaMvyLf4wl4A3b8IgndCyQF8TwfgsQ8T3VD8aX1/pA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -20652,9 +20547,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-regex": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha512-VlPiWmqmGJp0x0oK27Out1D+71nVVCTSdlbhIVoaBAj2lUgrNjBCRR9+llO4lTSb2O4r7PJg+RobRkhBrf6ofg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.26.0",
         "babel-types": "^6.26.0",
@@ -20663,9 +20557,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha512-RYqaPD0mQyQIFRu7Ho5wE2yvA/5jxqCIj/Lv4BXNq23mHYu/vxikOy2JueLiBxQknwapwrJeNCesvY0ZcfnlHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20676,9 +20569,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-replace-supers": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha512-sLI+u7sXJh6+ToqDr57Bv973kCepItDhMou0xCP2YPVmR1jkHSCY+p1no8xErbV1Siz5QE8qKT1WIwybSWlqjw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-optimise-call-expression": "^6.24.1",
         "babel-messages": "^6.23.0",
@@ -20690,9 +20582,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helpers": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha512-n7pFrqQm44TCYvrCDb0MqabAF+JUBq+ijBvNMUxpkLjJaAu32faIexewMumrH5KLLJ1HDyT0PTEqRyAe/GwwuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
@@ -20700,45 +20591,39 @@
     },
     "node_modules/ganache-core/node_modules/babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha512-B1M5KBP29248dViEo1owyY32lk1ZSH2DaNNrXLGt8lyjjHm7pBqAdQ7VKUPR6EEDO323+OvT3MQXbCin8ooWdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha512-4Zp4unmHgw30A1eWI5EpACji2qMocisdXhAftfhXoSV9j0Tvj6nRFE3tOmRY912E0FMRm/L5xWE7MGVT2FoLnw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha512-Z/flU+T9ta0aIEKl1tGEmN/pZiI1uXmCiGFRegKacQfEJzp7iNsKloZmyJlQr+75FCJtiFfGIK03SiCvCt9cPQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha512-Gx9CH3Q/3GKbhs07Bszw5fPTlU+ygrOGfAhEt7W2JICwufpC4SuO0mG0+4NykPBSYPMJhqvVlDBU17qB1D+hMQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha512-7BgYJujNCg0Ti3x0c/DL3tStvnKS6ktIYOmo9wginv/dfZOrbSZ+qG4IRRHMBOzZ5Awb1skTiAsQXg/+IWkZYw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-remap-async-to-generator": "^6.24.1",
         "babel-plugin-syntax-async-functions": "^6.8.0",
@@ -20747,27 +20632,24 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha512-PCqwwzODXW7JMrzu+yZIaYbPQSKjDTAsNNlK2l5Gg9g4rz2VzLnZsStvp/3c46GfXpwkyufb3NCyG9+50FF1Vg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha512-2+ujAT2UMBzYFm7tidUsYh+ZoIutxJ3pN9IYrF1/H6dCKtECfhmB8UkHVpyxDwkj0CYbQG35ykoz925TUnBc3A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha512-YiN6sFAQ5lML8JjCmr7uerS5Yc/EMbgg9G8ZNmk2E3nYX4ckHR01wrkeeMijEf5WHNK5TW0Sl0Uu3pv3EdOJWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.26.0",
         "babel-template": "^6.26.0",
@@ -20778,9 +20660,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha512-5Dy7ZbRinGrNtmWpquZKZ3EGY8sDgIVB4CU8Om8q8tnMLrD/m94cKglVcHps0BCTdZ0TJeeAWOq2TK9MIY6cag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-define-map": "^6.24.1",
         "babel-helper-function-name": "^6.24.1",
@@ -20795,9 +20676,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha512-C/uAv4ktFP/Hmh01gMTvYvICrKze0XVX9f2PdIXuriCSvUmV9j+u+BB9f5fJK3+878yMK6dkdcq+Ymr9mrcLzw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
@@ -20805,18 +20685,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha512-aNv/GDAW0j/f4Uy1OEPZn1mqD+Nfy9viFGBfQ5bZyT35YqOiqx7/tXdyfZkJ1sC21NyEsBdfDY6PYmLHF4r5iA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha512-ossocTuPOssfxO2h+Z3/Ea1Vo1wWx31Uqy9vIiJusOP4TbF7tPs9U0sJ9pX9OJPf4lXRGj5+6Gkl/HHKiAP5ug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -20824,18 +20702,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha512-DLuRwoygCoXx+YfxHLkVx5/NpeSbVwfoTeBykpJK7JhYWlL/O8hgAK/reforUnZDlxasOrVPPJVI/guE3dCwkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha512-iFp5KIcorf11iBqu/y/a7DK3MN5di3pNCzto61FqCNnUX4qeBwcV1SLqe10oXNnCaxBUImX3SckX2/o1nsrTcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20844,18 +20720,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha512-tjFl0cwMPpDYyoqYA9li1/7mGFit39XiNX5DKC/uCNjBctMxyL1/PT/l4rSlbvBG1pOKI88STRdUsWXB3/Q9hQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha512-LnIIdGWIKdw7zwckqx+eGjcS8/cl8D74A3BpJbGjKTFFNJSMrjN4bIh22HY1AlkUbeLG6X6OZj56BDvWD+OeFA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20864,9 +20738,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-plugin-transform-strict-mode": "^6.24.1",
         "babel-runtime": "^6.26.0",
@@ -20876,9 +20749,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha512-ONFIPsq8y4bls5PPsAWYXH/21Hqv64TBxdje0FvU3MhIV6QM2j5YS7KvAzg/nTIVLot2D2fmFQrFWCbgHlFEjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-hoist-variables": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20887,9 +20759,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha512-LpVbiT9CLsuAIp3IG0tfbVo81QIhn6pE8xBJ7XSeCtFlMltuar5VuBV6y6Q45tpui9QWcy5i0vLQfCfrnF7Kiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20898,9 +20769,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha512-8G5hpZMecb53vpD3mjs64NhI1au24TAmokQ4B+TBFBjN9cVoGoOvotdrMMRmHvVZUEvqGUPWL514woru1ChZMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-replace-supers": "^6.24.1",
         "babel-runtime": "^6.22.0"
@@ -20908,9 +20778,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha512-8HxlW+BB5HqniD+nLkQ4xSAVq3bR/pcYW9IigY+2y0dI+Y7INFeTbfAQr+63T3E4UDsZGjyb+l9txUnABWxlOQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-call-delegate": "^6.24.1",
         "babel-helper-get-function-arity": "^6.24.1",
@@ -20922,9 +20791,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha512-mDdocSfUVm1/7Jw/FIRNw9vPrBQNePy6wZJlR8HAUBLybNp1w/6lr6zZ2pjMShee65t/ybR5pT8ulkLzD1xwiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -20932,18 +20800,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha512-3Ghhi26r4l3d0Js933E5+IhHwk0A1yiutj9gwvzmFbVV0sPMYk2lekhOufHBswX7NCoSeF4Xrl3sCIuSIa+zOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha512-CYP359ADryTo3pCsH0oxRo/0yn6UsEZLqYohHmvLQdfS9xkf+MbCzE3/Kolw9OYIY4ZMilH25z/5CbQbwDD+lQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-regex": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20952,27 +20818,24 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha512-x8b9W0ngnKzDMHimVtTfn5ryimars1ByTqsfBDwAqLibmuuQY6pgBQi5z1ErIsUOWBdw1bW9FSz5RZUojM4apg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha512-fz6J2Sf4gYN6gWgRZaoFXmq93X+Li/8vf+fb0sGDVtdeWvxC9y5/bTD7bvfWMEq6zetGEHpWjtzRGSugt5kNqw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha512-v61Dbbihf5XxnYjtBN04B/JBvsScY37R1cZT5r9permN1cp+b70DY3Ib3fIkgn1DI9U3tGgBJZVD8p/mE/4JbQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-regex": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -20981,9 +20844,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha512-LzXDmbMkklvNhprr20//RStKVcT8Cu+SQtX18eMHLhjHf2yFzwtQ0S2f0jQ+89rokoNdmwoSqYzAhq86FxlLSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -20992,18 +20854,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-regenerator": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha512-LS+dBkUGlNR15/5WHKe/8Neawx663qttS6AGqoOUhICc9d1KciBvtrQSuc0PI+CxQ2Q/S1aKuJ+u64GtLdcEZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "regenerator-transform": "^0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha512-j3KtSpjyLSJxNoCDrhwiJad8kw0gJ9REGj8/CqL0HeRyLnvUNYV9zcqluL6QJSXh3nfsLEmSLvwRfGzrgR96Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -21011,9 +20871,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-preset-env": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-plugin-check-es2015-constants": "^6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -21049,18 +20908,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-preset-env/node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ganache-core/node_modules/babel-register": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha512-veliHlHX06wjaeY8xNITbveXSiI+ASFnOqvne/LaIJIqOWi2Ogmj91KOugEz/hoh/fwMhXNBJPCv8Xaz5CyM4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-core": "^6.26.0",
         "babel-runtime": "^6.26.0",
@@ -21073,18 +20930,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-register/node_modules/source-map-support": {
       "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "source-map": "^0.5.6"
       }
     },
     "node_modules/ganache-core/node_modules/babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -21092,9 +20947,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-template": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.26.0",
         "babel-traverse": "^6.26.0",
@@ -21105,9 +20959,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "babel-messages": "^6.23.0",
@@ -21122,33 +20975,29 @@
     },
     "node_modules/ganache-core/node_modules/babel-traverse/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-traverse/node_modules/globals": {
       "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/babel-traverse/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-types": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -21158,18 +21007,16 @@
     },
     "node_modules/ganache-core/node_modules/babel-types/node_modules/to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/babelify": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-      "integrity": "sha512-vID8Fz6pPN5pJMdlUnNFSfrlcx5MUule4k9aKs/zbZPyXxMTcRrB0M4Tarw22L8afr8eYSWxDPYCob3TdrqtlA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-core": "^6.0.14",
         "object-assign": "^4.0.0"
@@ -21177,18 +21024,16 @@
     },
     "node_modules/ganache-core/node_modules/babylon": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "babylon": "bin/babylon.js"
       }
     },
     "node_modules/ganache-core/node_modules/backoff": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "precond": "0.2"
       },
@@ -21198,15 +21043,13 @@
     },
     "node_modules/ganache-core/node_modules/balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/base": {
       "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -21222,18 +21065,16 @@
     },
     "node_modules/ganache-core/node_modules/base-x": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ganache-core/node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.0"
       },
@@ -21243,8 +21084,6 @@
     },
     "node_modules/ganache-core/node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true,
       "funding": [
         {
@@ -21259,28 +21098,26 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/ganache-core/node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/ganache-core/node_modules/bignumber.js": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": "*"
@@ -21288,9 +21125,8 @@
     },
     "node_modules/ganache-core/node_modules/bip39": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.5.0.tgz",
-      "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "create-hash": "^1.1.0",
         "pbkdf2": "^3.0.9",
@@ -21301,28 +21137,24 @@
     },
     "node_modules/ganache-core/node_modules/blakejs": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha512-1TSf2Cf2KycDPzjJpzamYhr6PFSEgKWyoc4rQ/BarXJzp/jM0FC7yP1rLWtMOWT2EIJtjPv9fwpKquRNbRV7Lg==",
-      "dev": true
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/ganache-core/node_modules/bluebird": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/bn.js": {
       "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/body-parser": {
       "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bytes": "3.1.0",
@@ -21342,9 +21174,8 @@
     },
     "node_modules/ganache-core/node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -21352,16 +21183,14 @@
     },
     "node_modules/ganache-core/node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/body-parser/node_modules/qs": {
       "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
         "node": ">=0.6"
@@ -21369,9 +21198,8 @@
     },
     "node_modules/ganache-core/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -21379,15 +21207,13 @@
     },
     "node_modules/ganache-core/node_modules/brorand": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -21399,9 +21225,8 @@
     },
     "node_modules/ganache-core/node_modules/browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "browserify-aes": "^1.0.4",
@@ -21411,9 +21236,8 @@
     },
     "node_modules/ganache-core/node_modules/browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
@@ -21424,9 +21248,8 @@
     },
     "node_modules/ganache-core/node_modules/browserify-rsa": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
-      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "^5.0.0",
@@ -21435,16 +21258,14 @@
     },
     "node_modules/ganache-core/node_modules/browserify-rsa/node_modules/bn.js": {
       "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-      "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/browserify-sign": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "bn.js": "^5.1.1",
@@ -21460,16 +21281,14 @@
     },
     "node_modules/ganache-core/node_modules/browserify-sign/node_modules/bn.js": {
       "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-      "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/browserify-sign/node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -21482,9 +21301,8 @@
     },
     "node_modules/ganache-core/node_modules/browserslist": {
       "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "caniuse-lite": "^1.0.30000844",
         "electron-to-chromium": "^1.3.47"
@@ -21495,18 +21313,16 @@
     },
     "node_modules/ganache-core/node_modules/bs58": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
       }
     },
     "node_modules/ganache-core/node_modules/bs58check": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -21515,8 +21331,6 @@
     },
     "node_modules/ganache-core/node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "funding": [
         {
@@ -21532,6 +21346,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -21539,38 +21354,33 @@
     },
     "node_modules/ganache-core/node_modules/buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/buffer-to-arraybuffer": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-      "integrity": "sha512-3dthu5CYiVB1DEJp61FtApNnNndTckcqe4pFcLdvHtrpG+kcyekCJKg4MRiDcFW7A6AODnXB9U4dwQiCW5kzJQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/bufferutil": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
-      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }
     },
     "node_modules/ganache-core/node_modules/bytes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.8"
@@ -21578,9 +21388,8 @@
     },
     "node_modules/ganache-core/node_modules/bytewise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytewise-core": "^1.2.2",
         "typewise": "^1.0.3"
@@ -21588,18 +21397,16 @@
     },
     "node_modules/ganache-core/node_modules/bytewise-core": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "typewise-core": "^1.2"
       }
     },
     "node_modules/ganache-core/node_modules/cache-base": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -21617,9 +21424,8 @@
     },
     "node_modules/ganache-core/node_modules/cacheable-request": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -21636,9 +21442,8 @@
     },
     "node_modules/ganache-core/node_modules/cacheable-request/node_modules/lowercase-keys": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=8"
@@ -21646,9 +21451,8 @@
     },
     "node_modules/ganache-core/node_modules/cachedown": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cachedown/-/cachedown-1.0.0.tgz",
-      "integrity": "sha512-t+yVk82vQWCJF3PsWHMld+jhhjkkWjcAzz8NbFx1iULOXWl8Tm/FdM4smZNVw3MRr0X+lVTx9PKzvEn4Ng19RQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "^2.4.1",
         "lru-cache": "^3.2.0"
@@ -21656,27 +21460,24 @@
     },
     "node_modules/ganache-core/node_modules/cachedown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/cachedown/node_modules/lru-cache": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-      "integrity": "sha512-91gyOKTc2k66UG6kHiH4h3S2eltcPwE1STVfMYC/NG+nZwf8IIuiamfmpGZjpbbxzSyEJaLC0tNSmhjlQUTJow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "pseudomap": "^1.0.1"
       }
     },
     "node_modules/ganache-core/node_modules/call-bind": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -21687,21 +21488,18 @@
     },
     "node_modules/ganache-core/node_modules/caniuse-lite": {
       "version": "1.0.30001174",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001174.tgz",
-      "integrity": "sha512-tqClL/4ThQq6cfFXH3oJL4rifFBeM6gTkphjao5kgwMaW9yn0tKgQLAEfKzDwj6HQWCB/aWo8kTFlSvIN8geEA==",
-      "dev": true
+      "dev": true,
+      "license": "CC-BY-4.0"
     },
     "node_modules/ganache-core/node_modules/caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ganache-core/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -21713,32 +21511,27 @@
     },
     "node_modules/ganache-core/node_modules/checkpoint-store": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
-      "integrity": "sha512-J/NdY2WvIx654cc6LWSq/IYFFCUf75fFTgwzFnmbqyORH4MwgiQCgswLLKBGzmsyTI5V7i5bp/So6sMbDWhedg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "functional-red-black-tree": "^1.0.1"
       }
     },
     "node_modules/ganache-core/node_modules/chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ci-info": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/cids": {
       "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
@@ -21754,10 +21547,8 @@
     },
     "node_modules/ganache-core/node_modules/cids/node_modules/multicodec": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "buffer": "^5.6.0",
@@ -21766,9 +21557,8 @@
     },
     "node_modules/ganache-core/node_modules/cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -21776,16 +21566,14 @@
     },
     "node_modules/ganache-core/node_modules/class-is": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/class-utils": {
       "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -21798,9 +21586,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
       },
@@ -21810,9 +21597,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -21822,9 +21608,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -21834,15 +21619,13 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -21852,9 +21635,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -21864,9 +21646,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -21878,27 +21659,24 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/kind-of": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/clone": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
     },
     "node_modules/ganache-core/node_modules/clone-response": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -21906,9 +21684,8 @@
     },
     "node_modules/ganache-core/node_modules/collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -21919,24 +21696,21 @@
     },
     "node_modules/ganache-core/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/ganache-core/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -21946,24 +21720,21 @@
     },
     "node_modules/ganache-core/node_modules/component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "engines": [
         "node >= 0.8"
       ],
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -21973,9 +21744,8 @@
     },
     "node_modules/ganache-core/node_modules/content-disposition": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "safe-buffer": "5.1.2"
@@ -21986,16 +21756,14 @@
     },
     "node_modules/ganache-core/node_modules/content-disposition/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/content-hash": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
-      "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "cids": "^0.7.1",
@@ -22005,9 +21773,8 @@
     },
     "node_modules/ganache-core/node_modules/content-type": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -22015,24 +21782,21 @@
     },
     "node_modules/ganache-core/node_modules/convert-source-map": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
     },
     "node_modules/ganache-core/node_modules/convert-source-map/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/cookie": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -22040,42 +21804,35 @@
     },
     "node_modules/ganache-core/node_modules/cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/cookiejar": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/core-js": {
       "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true,
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/core-js-pure": {
       "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.2.tgz",
-      "integrity": "sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw==",
-      "deprecated": "core-js-pure@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js-pure.",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -22083,15 +21840,13 @@
     },
     "node_modules/ganache-core/node_modules/core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/cors": {
       "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "object-assign": "^4",
@@ -22103,9 +21858,8 @@
     },
     "node_modules/ganache-core/node_modules/create-ecdh": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
-      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "^4.1.0",
@@ -22114,9 +21868,8 @@
     },
     "node_modules/ganache-core/node_modules/create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -22127,9 +21880,8 @@
     },
     "node_modules/ganache-core/node_modules/create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -22141,9 +21893,8 @@
     },
     "node_modules/ganache-core/node_modules/cross-fetch": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
-      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
@@ -22151,9 +21902,8 @@
     },
     "node_modules/ganache-core/node_modules/crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "browserify-cipher": "^1.0.0",
@@ -22174,9 +21924,8 @@
     },
     "node_modules/ganache-core/node_modules/d": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -22184,9 +21933,8 @@
     },
     "node_modules/ganache-core/node_modules/dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -22196,28 +21944,24 @@
     },
     "node_modules/ganache-core/node_modules/debug": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/ganache-core/node_modules/decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/ganache-core/node_modules/decompress-response": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -22228,9 +21972,8 @@
     },
     "node_modules/ganache-core/node_modules/deep-equal": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -22245,16 +21988,14 @@
     },
     "node_modules/ganache-core/node_modules/defer-to-connect": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/deferred-leveldown": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
-      "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~5.0.0",
         "inherits": "^2.0.3"
@@ -22265,9 +22006,8 @@
     },
     "node_modules/ganache-core/node_modules/deferred-leveldown/node_modules/abstract-leveldown": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       },
@@ -22277,9 +22017,8 @@
     },
     "node_modules/ganache-core/node_modules/define-properties": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "object-keys": "^1.0.12"
       },
@@ -22289,9 +22028,8 @@
     },
     "node_modules/ganache-core/node_modules/define-property": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -22302,24 +22040,21 @@
     },
     "node_modules/ganache-core/node_modules/defined": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/ganache-core/node_modules/depd": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -22327,9 +22062,8 @@
     },
     "node_modules/ganache-core/node_modules/des.js": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "inherits": "^2.0.1",
@@ -22338,16 +22072,14 @@
     },
     "node_modules/ganache-core/node_modules/destroy": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/detect-indent": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "repeating": "^2.0.0"
       },
@@ -22357,9 +22089,8 @@
     },
     "node_modules/ganache-core/node_modules/diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "^4.1.0",
@@ -22369,15 +22100,12 @@
     },
     "node_modules/ganache-core/node_modules/dom-walk": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
       "dev": true
     },
     "node_modules/ganache-core/node_modules/dotignore": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
-      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimatch": "^3.0.4"
       },
@@ -22387,16 +22115,14 @@
     },
     "node_modules/ganache-core/node_modules/duplexer3": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -22404,22 +22130,19 @@
     },
     "node_modules/ganache-core/node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/electron-to-chromium": {
       "version": "1.3.636",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.636.tgz",
-      "integrity": "sha512-Adcvng33sd3gTjNIDNXGD1G4H6qCImIy2euUJAQHtLNplEKU5WEz5KRJxupRNIIT8sD5oFZLTKBWAf12Bsz24A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/elliptic": {
       "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -22432,9 +22155,8 @@
     },
     "node_modules/ganache-core/node_modules/encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.8"
@@ -22442,18 +22164,16 @@
     },
     "node_modules/ganache-core/node_modules/encoding": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/ganache-core/node_modules/encoding-down": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
-      "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "^5.0.0",
         "inherits": "^2.0.3",
@@ -22467,9 +22187,8 @@
     },
     "node_modules/ganache-core/node_modules/encoding-down/node_modules/abstract-leveldown": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       },
@@ -22479,9 +22198,8 @@
     },
     "node_modules/ganache-core/node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -22491,18 +22209,16 @@
     },
     "node_modules/ganache-core/node_modules/end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
     },
     "node_modules/ganache-core/node_modules/errno": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -22512,9 +22228,8 @@
     },
     "node_modules/ganache-core/node_modules/es-abstract": {
       "version": "1.18.0-next.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -22538,9 +22253,8 @@
     },
     "node_modules/ganache-core/node_modules/es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -22555,9 +22269,8 @@
     },
     "node_modules/ganache-core/node_modules/es5-ext": {
       "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -22566,9 +22279,8 @@
     },
     "node_modules/ganache-core/node_modules/es6-iterator": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -22577,9 +22289,8 @@
     },
     "node_modules/ganache-core/node_modules/es6-symbol": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -22587,34 +22298,30 @@
     },
     "node_modules/ganache-core/node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/ganache-core/node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -22622,9 +22329,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-block-tracker": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
-      "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eth-query": "^2.1.0",
         "ethereumjs-tx": "^1.3.3",
@@ -22637,10 +22343,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-block-tracker/node_modules/ethereumjs-tx": {
       "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereum-common": "^0.0.18",
         "ethereumjs-util": "^5.0.0"
@@ -22648,9 +22352,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-block-tracker/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -22663,18 +22366,16 @@
     },
     "node_modules/ganache-core/node_modules/eth-block-tracker/node_modules/pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/eth-ens-namehash": {
       "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
-      "integrity": "sha512-VWEI1+KJfz4Km//dadyvBBoBeSQ0MHTXPvr8UIXiLW6IanxvAV+DmlZAijZwAyggqGUfwQBeHf7tc9wzc1piSw==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "idna-uts46-hx": "^2.3.1",
@@ -22683,9 +22384,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-infura": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.1.tgz",
-      "integrity": "sha512-W7zR4DZvyTn23Bxc0EWsq4XGDdD63+XPUCEhV2zQvQGavDVC4ZpFDK4k99qN7bd7/fjj37+rxmuBOBeIqCA5Mw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "cross-fetch": "^2.1.1",
         "eth-json-rpc-middleware": "^1.5.0",
@@ -22695,9 +22395,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
-      "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "async": "^2.5.0",
         "eth-query": "^2.1.2",
@@ -22716,27 +22415,24 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/abstract-leveldown": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/deferred-leveldown": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
       }
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-account": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
-      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-util": "^5.0.0",
         "rlp": "^2.0.0",
@@ -22745,10 +22441,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-block": {
       "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
-      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
         "ethereum-common": "0.2.0",
@@ -22759,16 +22453,13 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-block/node_modules/ethereum-common": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-tx": {
       "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereum-common": "^0.0.18",
         "ethereumjs-util": "^5.0.0"
@@ -22776,9 +22467,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -22791,10 +22481,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
-      "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/vm. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
         "async-eventemitter": "^0.2.2",
@@ -22811,10 +22499,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm/node_modules/ethereumjs-block": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
-      "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
         "ethereumjs-common": "^1.5.0",
@@ -22825,9 +22511,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm/node_modules/ethereumjs-block/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -22840,10 +22525,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm/node_modules/ethereumjs-tx": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
         "ethereumjs-util": "^6.0.0"
@@ -22851,9 +22534,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm/node_modules/ethereumjs-util": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -22866,30 +22548,26 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-codec": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-errors": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
       }
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha512-1qua0RHNtr4nrZBgYlpV0qHHeHpcRRWTxEZJ8xsemoHAXNL5tbooh4tPEEqIqsbWCAJBmUmkwYK/sW5OrFjWWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "level-errors": "^1.0.3",
@@ -22899,9 +22577,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -22911,9 +22588,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-ws": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-      "integrity": "sha512-XUTaO/+Db51Uiyp/t7fCMGVFOTdtLS/NIACxE/GHsij15mKzxksZifKVjlXDF41JMUP/oM1Oc4YNGdKnc3dVLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
         "xtend": "~2.1.1"
@@ -22921,9 +22597,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -22933,8 +22608,6 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
       "dev": true,
       "dependencies": {
         "object-keys": "~0.4.0"
@@ -22945,9 +22618,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/levelup": {
       "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
         "level-codec": "~7.0.0",
@@ -22960,15 +22632,13 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ltgt": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/memdown": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha512-iVrGHZB8i4OQfM155xx8akvG9FIj+ht14DX5CQkCTG4EHzZ3d3sgckIf/Lm9ivZalEsFuEVnWv2B2WZvbrro2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
         "functional-red-black-tree": "^1.0.1",
@@ -22980,18 +22650,16 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
         "ethereumjs-util": "^5.0.0",
@@ -23005,42 +22673,36 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/object-keys": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/semver": {
       "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-lib": {
       "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
-      "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "^4.11.6",
@@ -23053,9 +22715,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-query": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
-      "integrity": "sha512-srES0ZcvwkR/wd5OQBRA1bIJMww1skfGS0s8wlwK3/oNP4+wnds60krvu5R1QbpRQjMmpG5OMIWro5s7gvDPsA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "json-rpc-random-id": "^1.0.0",
         "xtend": "^4.0.1"
@@ -23063,10 +22724,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-sig-util": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-3.0.0.tgz",
-      "integrity": "sha512-4eFkMOhpGbTxBQ3AMzVf0haUX2uTur7DpWiHzWyTURa28BVJJtOkcb9Ok5TV0YvEPG61DODPW7ZUATbJTslioQ==",
-      "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "buffer": "^5.2.1",
         "elliptic": "^6.4.0",
@@ -23078,9 +22737,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-sig-util/node_modules/ethereumjs-abi": {
       "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
-      "integrity": "sha512-rCjJZ/AE96c/AAZc6O3kaog4FhOsAViaysBxqJNy2+LHP0ttH0zkZ7nXdVHOAyt6lFwLO0nlCwWszysG/ao1+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.10.0",
         "ethereumjs-util": "^4.3.0"
@@ -23088,9 +22746,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-sig-util/node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
       "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
-      "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.8.0",
         "create-hash": "^1.1.2",
@@ -23101,9 +22758,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-sig-util/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -23116,9 +22772,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.4.tgz",
-      "integrity": "sha512-NtlDnaVZah146Rm8HMRUNMgIwG/ED4jiqk0TME9zFheMl1jOp6jL1m0NKGjJwehXQ6ZKCPr16MTr+qspKpEXNg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "async": "^2.1.2",
         "clone": "^2.0.0",
@@ -23134,27 +22789,24 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/abstract-leveldown": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/deferred-leveldown": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
       }
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-account": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
-      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-util": "^5.0.0",
         "rlp": "^2.0.0",
@@ -23163,10 +22815,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-block": {
       "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
-      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
         "ethereum-common": "0.2.0",
@@ -23177,16 +22827,13 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-block/node_modules/ethereum-common": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-tx": {
       "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereum-common": "^0.0.18",
         "ethereumjs-util": "^5.0.0"
@@ -23194,9 +22841,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -23209,10 +22855,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
-      "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/vm. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
         "async-eventemitter": "^0.2.2",
@@ -23229,10 +22873,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm/node_modules/ethereumjs-block": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
-      "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
         "ethereumjs-common": "^1.5.0",
@@ -23243,9 +22885,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm/node_modules/ethereumjs-block/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -23258,10 +22899,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm/node_modules/ethereumjs-tx": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
         "ethereumjs-util": "^6.0.0"
@@ -23269,9 +22908,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm/node_modules/ethereumjs-util": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -23284,30 +22922,26 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-codec": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-errors": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
       }
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha512-1qua0RHNtr4nrZBgYlpV0qHHeHpcRRWTxEZJ8xsemoHAXNL5tbooh4tPEEqIqsbWCAJBmUmkwYK/sW5OrFjWWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "level-errors": "^1.0.3",
@@ -23317,9 +22951,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -23329,9 +22962,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-ws": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-      "integrity": "sha512-XUTaO/+Db51Uiyp/t7fCMGVFOTdtLS/NIACxE/GHsij15mKzxksZifKVjlXDF41JMUP/oM1Oc4YNGdKnc3dVLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
         "xtend": "~2.1.1"
@@ -23339,9 +22971,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -23351,8 +22982,6 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
       "dev": true,
       "dependencies": {
         "object-keys": "~0.4.0"
@@ -23363,9 +22992,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/levelup": {
       "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
         "level-codec": "~7.0.0",
@@ -23378,15 +23006,13 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ltgt": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/memdown": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha512-iVrGHZB8i4OQfM155xx8akvG9FIj+ht14DX5CQkCTG4EHzZ3d3sgckIf/Lm9ivZalEsFuEVnWv2B2WZvbrro2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
         "functional-red-black-tree": "^1.0.1",
@@ -23398,18 +23024,16 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
         "ethereumjs-util": "^5.0.0",
@@ -23423,43 +23047,36 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/object-keys": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/semver": {
       "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethashjs": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
-      "integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/ethash. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
         "buffer-xor": "^2.0.1",
@@ -23469,24 +23086,21 @@
     },
     "node_modules/ganache-core/node_modules/ethashjs/node_modules/bn.js": {
       "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-      "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethashjs/node_modules/buffer-xor": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
-      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/ganache-core/node_modules/ethashjs/node_modules/ethereumjs-util": {
       "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.7.tgz",
-      "integrity": "sha512-vU5rtZBlZsgkTw3o6PDKyB8li2EgLavnAbsKcfsH2YhHH1Le+PP8vEiMnAnvgc1B6uMoaM5GDCrVztBw0Q5K9g==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^5.1.2",
@@ -23501,9 +23115,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereum-bloom-filters": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
-      "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "js-sha3": "^0.8.0"
@@ -23511,22 +23124,19 @@
     },
     "node_modules/ganache-core/node_modules/ethereum-bloom-filters/node_modules/js-sha3": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ethereum-common": {
       "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-      "integrity": "sha512-EoltVQTRNg2Uy4o84qpa2aXymXDJhxm7eos/ACOg0DG4baAbMjhbdAEsx9GeE8sC3XCxnYvrrzZDH8D8MtA2iQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -23547,9 +23157,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-abi": {
       "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -23557,10 +23166,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-account": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
-      "integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
-      "deprecated": "Please use Util.Account class found on package ethereumjs-util@^7.0.6 https://github.com/ethereumjs/ethereumjs-util/releases/tag/v7.0.6",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-util": "^6.0.0",
         "rlp": "^2.2.1",
@@ -23569,10 +23176,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
-      "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
         "ethereumjs-common": "^1.5.0",
@@ -23583,27 +23188,24 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/abstract-leveldown": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/deferred-leveldown": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -23616,30 +23218,26 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-codec": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-errors": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha512-1qua0RHNtr4nrZBgYlpV0qHHeHpcRRWTxEZJ8xsemoHAXNL5tbooh4tPEEqIqsbWCAJBmUmkwYK/sW5OrFjWWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "level-errors": "^1.0.3",
@@ -23649,9 +23247,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -23661,9 +23258,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-ws": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-      "integrity": "sha512-XUTaO/+Db51Uiyp/t7fCMGVFOTdtLS/NIACxE/GHsij15mKzxksZifKVjlXDF41JMUP/oM1Oc4YNGdKnc3dVLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
         "xtend": "~2.1.1"
@@ -23671,9 +23267,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -23683,8 +23278,6 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
       "dev": true,
       "dependencies": {
         "object-keys": "~0.4.0"
@@ -23695,9 +23288,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/levelup": {
       "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
         "level-codec": "~7.0.0",
@@ -23710,15 +23302,13 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/ltgt": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/memdown": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha512-iVrGHZB8i4OQfM155xx8akvG9FIj+ht14DX5CQkCTG4EHzZ3d3sgckIf/Lm9ivZalEsFuEVnWv2B2WZvbrro2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
         "functional-red-black-tree": "^1.0.1",
@@ -23730,18 +23320,16 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
         "ethereumjs-util": "^5.0.0",
@@ -23755,43 +23343,36 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/object-keys": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/semver": {
       "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-blockchain": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
-      "integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
-      "deprecated": "New package name format for new versions: @ethereumjs/blockchain. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.6.1",
         "ethashjs": "~0.0.7",
@@ -23807,17 +23388,13 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-common": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
-      "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ==",
-      "deprecated": "New package name format for new versions: @ethereumjs/common. Please update.",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-tx": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
         "ethereumjs-util": "^6.0.0"
@@ -23825,9 +23402,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-util": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -23840,10 +23416,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
-      "integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/vm. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
         "async-eventemitter": "^0.2.2",
@@ -23864,48 +23438,42 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/abstract-leveldown": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/deferred-leveldown": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-codec": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-errors": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha512-1qua0RHNtr4nrZBgYlpV0qHHeHpcRRWTxEZJ8xsemoHAXNL5tbooh4tPEEqIqsbWCAJBmUmkwYK/sW5OrFjWWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "level-errors": "^1.0.3",
@@ -23915,9 +23483,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -23927,9 +23494,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-ws": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-      "integrity": "sha512-XUTaO/+Db51Uiyp/t7fCMGVFOTdtLS/NIACxE/GHsij15mKzxksZifKVjlXDF41JMUP/oM1Oc4YNGdKnc3dVLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
         "xtend": "~2.1.1"
@@ -23937,9 +23503,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -23949,8 +23514,6 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
       "dev": true,
       "dependencies": {
         "object-keys": "~0.4.0"
@@ -23961,9 +23524,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/levelup": {
       "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
         "level-codec": "~7.0.0",
@@ -23976,15 +23538,13 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/ltgt": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/memdown": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha512-iVrGHZB8i4OQfM155xx8akvG9FIj+ht14DX5CQkCTG4EHzZ3d3sgckIf/Lm9ivZalEsFuEVnWv2B2WZvbrro2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
         "functional-red-black-tree": "^1.0.1",
@@ -23996,18 +23556,16 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
         "ethereumjs-util": "^5.0.0",
@@ -24021,15 +23579,13 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/merkle-patricia-tree/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -24042,36 +23598,31 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/object-keys": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/semver": {
       "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-wallet": {
       "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz",
-      "integrity": "sha512-MDwjwB9VQVnpp/Dc1XzA6J1a3wgHQ4hSvA1uWNatdpOrtCbPVuQSKSyRnjLvS0a+KKMw2pvQ9Ybqpb3+eW8oNA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "aes-js": "^3.1.1",
@@ -24087,9 +23638,8 @@
     },
     "node_modules/ganache-core/node_modules/ethjs-unit": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "4.11.6",
@@ -24102,16 +23652,14 @@
     },
     "node_modules/ganache-core/node_modules/ethjs-unit/node_modules/bn.js": {
       "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ethjs-util": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -24123,25 +23671,22 @@
     },
     "node_modules/ganache-core/node_modules/eventemitter3": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/events": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
     },
     "node_modules/ganache-core/node_modules/evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -24149,9 +23694,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^2.3.3",
         "define-property": "^0.2.5",
@@ -24167,18 +23711,16 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
       },
@@ -24188,9 +23730,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -24200,9 +23741,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -24212,9 +23752,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -24224,15 +23763,13 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -24242,9 +23779,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -24254,9 +23790,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -24268,33 +23803,29 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/kind-of": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/express": {
       "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "accepts": "~1.3.7",
@@ -24334,9 +23865,8 @@
     },
     "node_modules/ganache-core/node_modules/express/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -24344,16 +23874,14 @@
     },
     "node_modules/ganache-core/node_modules/express/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/express/node_modules/qs": {
       "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
         "node": ">=0.6"
@@ -24361,37 +23889,32 @@
     },
     "node_modules/ganache-core/node_modules/express/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ext": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "type": "^2.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/ext/node_modules/type": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-      "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -24402,9 +23925,8 @@
     },
     "node_modules/ganache-core/node_modules/extglob": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -24421,9 +23943,8 @@
     },
     "node_modules/ganache-core/node_modules/extglob/node_modules/define-property": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.0"
       },
@@ -24433,9 +23954,8 @@
     },
     "node_modules/ganache-core/node_modules/extglob/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -24445,66 +23965,58 @@
     },
     "node_modules/ganache-core/node_modules/extglob/node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/fake-merkle-patricia-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
-      "integrity": "sha512-Tgq37lkc9pUIgIKw5uitNUKcgcYL3R6JvXtKQbOf/ZSavXbidsksgp/pAY6p//uhw0I4yoMsvTSovvVIsk/qxA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "checkpoint-store": "^1.1.0"
       }
     },
     "node_modules/ganache-core/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/fetch-ponyfill": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
-      "integrity": "sha512-knK9sGskIg2T7OnYLdZ2hZXn0CtDrAIBxYQLpmEf0BqfdWnwmM1weccUl5+4EdA44tzNSFAuxITPbXtPehUB3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "~1.7.1"
       }
     },
     "node_modules/ganache-core/node_modules/fetch-ponyfill/node_modules/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/fetch-ponyfill/node_modules/node-fetch": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -24512,9 +24024,8 @@
     },
     "node_modules/ganache-core/node_modules/finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -24531,9 +24042,8 @@
     },
     "node_modules/ganache-core/node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -24541,16 +24051,14 @@
     },
     "node_modules/ganache-core/node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz",
-      "integrity": "sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "fs-extra": "^4.0.3",
         "micromatch": "^3.1.4"
@@ -24558,9 +24066,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/braces": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "arr-flatten": "^1.1.0",
         "array-unique": "^0.3.2",
@@ -24579,9 +24086,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -24591,9 +24097,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/fill-range": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "is-number": "^3.0.0",
@@ -24606,9 +24111,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -24618,9 +24122,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/fs-extra": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -24629,24 +24132,21 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/is-number": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -24656,9 +24156,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -24668,9 +24167,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/micromatch": {
       "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -24692,9 +24190,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
@@ -24705,42 +24202,37 @@
     },
     "node_modules/ganache-core/node_modules/flow-stoplight": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/flow-stoplight/-/flow-stoplight-1.0.0.tgz",
-      "integrity": "sha512-rDjbZUKpN8OYhB0IE/vY/I8UWO/602IIJEU/76Tv4LvYnwHCk0BCsvz4eRr9n+FQcri7L5cyaXOo0+/Kh4HisA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/for-each": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
       }
     },
     "node_modules/ganache-core/node_modules/for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/ganache-core/node_modules/form-data": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -24752,9 +24244,8 @@
     },
     "node_modules/ganache-core/node_modules/forwarded": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha512-Ua9xNhH0b8pwE3yRbFfXJvfdWF0UHNCdeyb2sbi9Ul/M+r3PTdrz7Cv4SCfZRMjmzEM9PhraqfZFbGTIg3OMyA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -24762,9 +24253,8 @@
     },
     "node_modules/ganache-core/node_modules/fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "map-cache": "^0.2.2"
       },
@@ -24774,9 +24264,8 @@
     },
     "node_modules/ganache-core/node_modules/fresh": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -24784,9 +24273,8 @@
     },
     "node_modules/ganache-core/node_modules/fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -24798,27 +24286,23 @@
     },
     "node_modules/ganache-core/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/get-intrinsic": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
-      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -24830,9 +24314,8 @@
     },
     "node_modules/ganache-core/node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "pump": "^3.0.0"
@@ -24846,27 +24329,24 @@
     },
     "node_modules/ganache-core/node_modules/get-value": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/glob": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -24881,9 +24361,8 @@
     },
     "node_modules/ganache-core/node_modules/global": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -24891,9 +24370,8 @@
     },
     "node_modules/ganache-core/node_modules/got": {
       "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@sindresorhus/is": "^0.14.0",
@@ -24914,9 +24392,8 @@
     },
     "node_modules/ganache-core/node_modules/got/node_modules/get-stream": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "pump": "^3.0.0"
@@ -24927,25 +24404,21 @@
     },
     "node_modules/ganache-core/node_modules/graceful-fs": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/ganache-core/node_modules/har-validator": {
       "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -24956,9 +24429,8 @@
     },
     "node_modules/ganache-core/node_modules/has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -24968,9 +24440,8 @@
     },
     "node_modules/ganache-core/node_modules/has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -24980,27 +24451,24 @@
     },
     "node_modules/ganache-core/node_modules/has-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/ganache-core/node_modules/has-symbol-support-x": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": "*"
@@ -25008,9 +24476,8 @@
     },
     "node_modules/ganache-core/node_modules/has-symbols": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -25020,9 +24487,8 @@
     },
     "node_modules/ganache-core/node_modules/has-to-string-tag-x": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "has-symbol-support-x": "^1.4.1"
@@ -25033,9 +24499,8 @@
     },
     "node_modules/ganache-core/node_modules/has-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -25047,9 +24512,8 @@
     },
     "node_modules/ganache-core/node_modules/has-values": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -25060,15 +24524,13 @@
     },
     "node_modules/ganache-core/node_modules/has-values/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/has-values/node_modules/is-number": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -25078,9 +24540,8 @@
     },
     "node_modules/ganache-core/node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -25090,9 +24551,8 @@
     },
     "node_modules/ganache-core/node_modules/has-values/node_modules/kind-of": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-      "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -25102,9 +24562,8 @@
     },
     "node_modules/ganache-core/node_modules/hash-base": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -25116,9 +24575,8 @@
     },
     "node_modules/ganache-core/node_modules/hash-base/node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -25130,9 +24588,8 @@
     },
     "node_modules/ganache-core/node_modules/hash.js": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -25140,15 +24597,12 @@
     },
     "node_modules/ganache-core/node_modules/heap": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
-      "integrity": "sha512-MzzWcnfB1e4EG2vHi3dXHoBupmuXNZzx6pY6HldVS55JKKBoq3xOyzfSaZRkJp37HIhEYC78knabHff3zc4dQQ==",
       "dev": true
     },
     "node_modules/ganache-core/node_modules/hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -25157,9 +24611,8 @@
     },
     "node_modules/ganache-core/node_modules/home-or-tmp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha512-ycURW7oUxE2sNiPVw1HVEFsW+ecOpJ5zaj7eC0RlwhibhRBod20muUN8qu/gzx956YrLolVvs1MTXwKgC2rVEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
@@ -25170,16 +24623,14 @@
     },
     "node_modules/ganache-core/node_modules/http-cache-semantics": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/http-errors": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "depd": "~1.1.2",
@@ -25194,23 +24645,20 @@
     },
     "node_modules/ganache-core/node_modules/http-errors/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/http-https": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-      "integrity": "sha512-o0PWwVCSp3O0wS6FvNr6xfBCHgt0m1tvPLFOCc2iFDKTRAXhB7m8klDf7ErowFH8POa6dVdGatKU5I1YYwzUyg==",
       "dev": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -25223,9 +24671,8 @@
     },
     "node_modules/ganache-core/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -25236,9 +24683,8 @@
     },
     "node_modules/ganache-core/node_modules/idna-uts46-hx": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
-      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "punycode": "2.1.0"
@@ -25249,9 +24695,8 @@
     },
     "node_modules/ganache-core/node_modules/idna-uts46-hx/node_modules/punycode": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha512-Yxz2kRwT90aPiWEMHVYnEf4+rhwF1tBmmZ4KepCP+Wkium9JxtWnUm1nqGwpiAHr/tnTSeHqr3wb++jgSkXjhA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=6"
@@ -25259,8 +24704,6 @@
     },
     "node_modules/ganache-core/node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true,
       "funding": [
         {
@@ -25275,19 +24718,18 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ganache-core/node_modules/immediate": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -25295,24 +24737,21 @@
     },
     "node_modules/ganache-core/node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/invariant": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.10"
@@ -25320,9 +24759,8 @@
     },
     "node_modules/ganache-core/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
       },
@@ -25332,9 +24770,8 @@
     },
     "node_modules/ganache-core/node_modules/is-arguments": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
-      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0"
       },
@@ -25347,9 +24784,8 @@
     },
     "node_modules/ganache-core/node_modules/is-callable": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -25359,9 +24795,8 @@
     },
     "node_modules/ganache-core/node_modules/is-ci": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ci-info": "^2.0.0"
       },
@@ -25371,9 +24806,8 @@
     },
     "node_modules/ganache-core/node_modules/is-data-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
       },
@@ -25383,9 +24817,8 @@
     },
     "node_modules/ganache-core/node_modules/is-date-object": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -25395,9 +24828,8 @@
     },
     "node_modules/ganache-core/node_modules/is-descriptor": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^1.0.0",
         "is-data-descriptor": "^1.0.0",
@@ -25409,9 +24841,8 @@
     },
     "node_modules/ganache-core/node_modules/is-extendable": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4"
       },
@@ -25421,9 +24852,8 @@
     },
     "node_modules/ganache-core/node_modules/is-finite": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       },
@@ -25433,24 +24863,21 @@
     },
     "node_modules/ganache-core/node_modules/is-fn": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
-      "integrity": "sha512-XoFPJQmsAShb3jEQRfzf2rqXavq7fIqF/jOekp308JlThqrODnMpweVSGilKTCXELfLhltGP2AGgbQGVP8F1dg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/is-function": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/is-hex-prefixed": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
@@ -25458,9 +24885,8 @@
     },
     "node_modules/ganache-core/node_modules/is-negative-zero": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -25470,9 +24896,8 @@
     },
     "node_modules/ganache-core/node_modules/is-object": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
-      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -25480,9 +24905,8 @@
     },
     "node_modules/ganache-core/node_modules/is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -25490,9 +24914,8 @@
     },
     "node_modules/ganache-core/node_modules/is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -25502,9 +24925,8 @@
     },
     "node_modules/ganache-core/node_modules/is-regex": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.1"
       },
@@ -25517,9 +24939,8 @@
     },
     "node_modules/ganache-core/node_modules/is-retry-allowed": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -25527,9 +24948,8 @@
     },
     "node_modules/ganache-core/node_modules/is-symbol": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.1"
       },
@@ -25542,51 +24962,44 @@
     },
     "node_modules/ganache-core/node_modules/is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/is-windows": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/isurl": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "has-to-string-tag-x": "^1.2.0",
@@ -25598,35 +25011,30 @@
     },
     "node_modules/ganache-core/node_modules/js-sha3": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/json-buffer": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/json-rpc-engine": {
       "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.8.0.tgz",
-      "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "async": "^2.0.1",
         "babel-preset-env": "^1.7.0",
@@ -25638,72 +25046,59 @@
     },
     "node_modules/ganache-core/node_modules/json-rpc-error": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
-      "integrity": "sha512-EwUeWP+KgAZ/xqFpaP6YDAXMtCJi+o/QQpCQFIYyxr01AdADi2y413eM8hSqJcoQym9WMePAJWoaODEJufC4Ug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1"
       }
     },
     "node_modules/ganache-core/node_modules/json-rpc-random-id": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
-      "integrity": "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha512-a3xHnILGMtk+hDOqNwHzF6e2fNbiMrXZvxKQiEv2MlgQP+pjIOzqAmKYD2mDpXYE/44M7g+n9p2bKkYWDUcXCQ==",
       "dev": true
     },
     "node_modules/ganache-core/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jsonify": "~0.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/ganache-core/node_modules/jsonify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
       "dev": true,
-      "engines": {
-        "node": "*"
-      }
+      "license": "Public Domain"
     },
     "node_modules/ganache-core/node_modules/jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha512-4Dj8Rf+fQ+/Pn7C5qeEX02op1WfOss3PKTE9Nsop3Dx+6UPxlm1dr/og7o2cRa5hNN07CACr4NFzRLtj/rjWog==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -25727,9 +25122,8 @@
     },
     "node_modules/ganache-core/node_modules/keyv": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "json-buffer": "3.0.0"
@@ -25737,27 +25131,24 @@
     },
     "node_modules/ganache-core/node_modules/kind-of": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/klaw-sync": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/ganache-core/node_modules/level-codec": {
       "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -25767,9 +25158,8 @@
     },
     "node_modules/ganache-core/node_modules/level-errors": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
       },
@@ -25779,9 +25169,8 @@
     },
     "node_modules/ganache-core/node_modules/level-iterator-stream": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-      "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.5",
@@ -25793,9 +25182,8 @@
     },
     "node_modules/ganache-core/node_modules/level-mem": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
-      "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "level-packager": "~4.0.0",
         "memdown": "~3.0.0"
@@ -25806,9 +25194,8 @@
     },
     "node_modules/ganache-core/node_modules/level-mem/node_modules/abstract-leveldown": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       },
@@ -25818,15 +25205,13 @@
     },
     "node_modules/ganache-core/node_modules/level-mem/node_modules/ltgt": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/level-mem/node_modules/memdown": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-      "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~5.0.0",
         "functional-red-black-tree": "~1.0.1",
@@ -25841,15 +25226,13 @@
     },
     "node_modules/ganache-core/node_modules/level-mem/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/level-packager": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
-      "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "encoding-down": "~5.0.0",
         "levelup": "^3.0.0"
@@ -25860,18 +25243,16 @@
     },
     "node_modules/ganache-core/node_modules/level-post": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-      "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ltgt": "^2.1.2"
       }
     },
     "node_modules/ganache-core/node_modules/level-sublevel": {
       "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
-      "integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytewise": "~1.1.0",
         "level-codec": "^9.0.0",
@@ -25887,9 +25268,8 @@
     },
     "node_modules/ganache-core/node_modules/level-ws": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
-      "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.8",
@@ -25901,9 +25281,8 @@
     },
     "node_modules/ganache-core/node_modules/levelup": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
-      "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~4.0.0",
         "level-errors": "~2.0.0",
@@ -25916,9 +25295,8 @@
     },
     "node_modules/ganache-core/node_modules/levelup/node_modules/level-iterator-stream": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
-      "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.3.6",
@@ -25930,21 +25308,18 @@
     },
     "node_modules/ganache-core/node_modules/lodash": {
       "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/looper": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-      "integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -25954,9 +25329,8 @@
     },
     "node_modules/ganache-core/node_modules/lowercase-keys": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -25964,33 +25338,29 @@
     },
     "node_modules/ganache-core/node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
     },
     "node_modules/ganache-core/node_modules/ltgt": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-      "integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/map-cache": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/map-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "object-visit": "^1.0.0"
       },
@@ -26000,9 +25370,8 @@
     },
     "node_modules/ganache-core/node_modules/md5.js": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -26011,9 +25380,8 @@
     },
     "node_modules/ganache-core/node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -26021,16 +25389,14 @@
     },
     "node_modules/ganache-core/node_modules/merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/merkle-patricia-tree": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
-      "integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.6.1",
         "ethereumjs-util": "^5.2.0",
@@ -26043,9 +25409,8 @@
     },
     "node_modules/ganache-core/node_modules/merkle-patricia-tree/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -26058,9 +25423,8 @@
     },
     "node_modules/ganache-core/node_modules/merkle-patricia-tree/node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -26072,9 +25436,8 @@
     },
     "node_modules/ganache-core/node_modules/methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -26082,9 +25445,8 @@
     },
     "node_modules/ganache-core/node_modules/miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -26095,9 +25457,8 @@
     },
     "node_modules/ganache-core/node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "bin": {
         "mime": "cli.js"
@@ -26108,18 +25469,16 @@
     },
     "node_modules/ganache-core/node_modules/mime-db": {
       "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/ganache-core/node_modules/mime-types": {
       "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.45.0"
       },
@@ -26129,9 +25488,8 @@
     },
     "node_modules/ganache-core/node_modules/mimic-response": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=4"
@@ -26139,8 +25497,6 @@
     },
     "node_modules/ganache-core/node_modules/min-document": {
       "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
       "dev": true,
       "dependencies": {
         "dom-walk": "^0.1.0"
@@ -26148,21 +25504,18 @@
     },
     "node_modules/ganache-core/node_modules/minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -26172,15 +25525,13 @@
     },
     "node_modules/ganache-core/node_modules/minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/minizlib": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
@@ -26188,9 +25539,8 @@
     },
     "node_modules/ganache-core/node_modules/minizlib/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
@@ -26199,9 +25549,8 @@
     },
     "node_modules/ganache-core/node_modules/mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -26212,9 +25561,8 @@
     },
     "node_modules/ganache-core/node_modules/mkdirp": {
       "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -26224,10 +25572,8 @@
     },
     "node_modules/ganache-core/node_modules/mkdirp-promise": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
-      "integrity": "sha512-Hepn5kb1lJPtVW84RFT40YG1OddBNTOVUZR2bzQUHc+Z03en8/3uX0+060JDhcEzyO08HmipsN9DcnFMxhIL9w==",
-      "deprecated": "This package is broken and no longer maintained. 'mkdirp' itself supports promises now, please switch to that.",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "mkdirp": "*"
@@ -26238,23 +25584,19 @@
     },
     "node_modules/ganache-core/node_modules/mock-fs": {
       "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
-      "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/multibase": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "base-x": "^3.0.8",
@@ -26263,10 +25605,8 @@
     },
     "node_modules/ganache-core/node_modules/multicodec": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
-      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
-      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "varint": "^5.0.0"
@@ -26274,9 +25614,8 @@
     },
     "node_modules/ganache-core/node_modules/multihashes": {
       "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
@@ -26286,10 +25625,8 @@
     },
     "node_modules/ganache-core/node_modules/multihashes/node_modules/multibase": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "base-x": "^3.0.8",
@@ -26298,16 +25635,14 @@
     },
     "node_modules/ganache-core/node_modules/nano-json-stream-parser": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
-      "integrity": "sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -26327,9 +25662,8 @@
     },
     "node_modules/ganache-core/node_modules/negotiator": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -26337,15 +25671,13 @@
     },
     "node_modules/ganache-core/node_modules/next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/node-addon-api": {
       "version": "2.0.2",
@@ -26355,9 +25687,8 @@
     },
     "node_modules/ganache-core/node_modules/node-fetch": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha512-IHLHYskTc2arMYsHZH82PVX8CSKT5lzb7AXeyO06QnjGDKtkv+pv3mEki6S7reB/x1QPo+YPxQRNEVgR5V/w3Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -26375,9 +25706,8 @@
     },
     "node_modules/ganache-core/node_modules/normalize-url": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=8"
@@ -26385,9 +25715,8 @@
     },
     "node_modules/ganache-core/node_modules/number-to-bn": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "4.11.6",
@@ -26400,34 +25729,30 @@
     },
     "node_modules/ganache-core/node_modules/number-to-bn/node_modules/bn.js": {
       "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/ganache-core/node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/object-copy": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -26439,9 +25764,8 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
       },
@@ -26451,9 +25775,8 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -26463,15 +25786,13 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -26481,9 +25802,8 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -26495,18 +25815,16 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -26516,18 +25834,16 @@
     },
     "node_modules/ganache-core/node_modules/object-inspect": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ganache-core/node_modules/object-is": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
-      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3"
@@ -26541,18 +25857,16 @@
     },
     "node_modules/ganache-core/node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/ganache-core/node_modules/object-visit": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.0"
       },
@@ -26562,9 +25876,8 @@
     },
     "node_modules/ganache-core/node_modules/object.assign": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -26580,9 +25893,8 @@
     },
     "node_modules/ganache-core/node_modules/object.getownpropertydescriptors": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
-      "integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -26597,9 +25909,8 @@
     },
     "node_modules/ganache-core/node_modules/object.pick": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -26609,9 +25920,8 @@
     },
     "node_modules/ganache-core/node_modules/oboe": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
-      "integrity": "sha512-ymBJ4xSC6GBXLT9Y7lirj+xbqBLa+jADGJldGEYG7u8sZbS9GyG+u1Xk9c5cbriKwSpCg41qUhPjvU5xOpvIyQ==",
       "dev": true,
+      "license": "BSD",
       "optional": true,
       "dependencies": {
         "http-https": "^1.0.0"
@@ -26619,9 +25929,8 @@
     },
     "node_modules/ganache-core/node_modules/on-finished": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ee-first": "1.1.1"
@@ -26632,36 +25941,32 @@
     },
     "node_modules/ganache-core/node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/ganache-core/node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/p-cancelable": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=6"
@@ -26669,9 +25974,8 @@
     },
     "node_modules/ganache-core/node_modules/p-timeout": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-      "integrity": "sha512-gb0ryzr+K2qFqFv6qi3khoeqMZF/+ajxQipEF6NteZVnvz9tzdsfAVj3lYtn1gAXvH5lfLwfxEII799gt/mRIA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "p-finally": "^1.0.0"
@@ -26682,9 +25986,8 @@
     },
     "node_modules/ganache-core/node_modules/p-timeout/node_modules/p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=4"
@@ -26692,9 +25995,8 @@
     },
     "node_modules/ganache-core/node_modules/parse-asn1": {
       "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
-      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "asn1.js": "^5.2.0",
@@ -26706,15 +26008,13 @@
     },
     "node_modules/ganache-core/node_modules/parse-headers": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.8"
@@ -26722,18 +26022,16 @@
     },
     "node_modules/ganache-core/node_modules/pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/patch-package": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.2.2.tgz",
-      "integrity": "sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^2.4.2",
@@ -26757,9 +26055,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -26773,27 +26070,24 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -26803,27 +26097,24 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/slash": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/tmp": {
       "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -26833,9 +26124,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -26845,31 +26135,27 @@
     },
     "node_modules/ganache-core/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/pbkdf2": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -26883,23 +26169,19 @@
     },
     "node_modules/ganache-core/node_modules/performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/precond": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -26907,9 +26189,8 @@
     },
     "node_modules/ganache-core/node_modules/prepend-http": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=4"
@@ -26917,33 +26198,29 @@
     },
     "node_modules/ganache-core/node_modules/private": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/ganache-core/node_modules/process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       }
     },
     "node_modules/ganache-core/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/promise-to-callback": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
-      "integrity": "sha512-uhMIZmKM5ZteDMfLgJnoSq9GCwsNKrYau73Awf1jIy6/eUcuuZ3P+CD9zUv0kJsIUbU+x6uLNIhXhLHDs1pNPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-fn": "^1.0.0",
         "set-immediate-shim": "^1.0.1"
@@ -26954,9 +26231,8 @@
     },
     "node_modules/ganache-core/node_modules/proxy-addr": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "forwarded": "~0.1.2",
@@ -26968,27 +26244,23 @@
     },
     "node_modules/ganache-core/node_modules/prr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/psl": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "^4.1.0",
@@ -27001,21 +26273,18 @@
     },
     "node_modules/ganache-core/node_modules/pull-cat": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-      "integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pull-defer": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pull-level": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-      "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "level-post": "^1.0.7",
         "pull-cat": "^1.1.9",
@@ -27028,9 +26297,8 @@
     },
     "node_modules/ganache-core/node_modules/pull-live": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-      "integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pull-cat": "^1.1.9",
         "pull-stream": "^3.4.0"
@@ -27038,30 +26306,26 @@
     },
     "node_modules/ganache-core/node_modules/pull-pushable": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-      "integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pull-stream": {
       "version": "3.6.14",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pull-window": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-      "integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "looper": "^2.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/pump": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -27070,27 +26334,24 @@
     },
     "node_modules/ganache-core/node_modules/punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/ganache-core/node_modules/qs": {
       "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/ganache-core/node_modules/query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "decode-uri-component": "^0.2.0",
@@ -27103,18 +26364,16 @@
     },
     "node_modules/ganache-core/node_modules/randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/ganache-core/node_modules/randomfill": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "randombytes": "^2.0.5",
@@ -27123,9 +26382,8 @@
     },
     "node_modules/ganache-core/node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -27133,9 +26391,8 @@
     },
     "node_modules/ganache-core/node_modules/raw-body": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bytes": "3.1.0",
@@ -27149,9 +26406,8 @@
     },
     "node_modules/ganache-core/node_modules/readable-stream": {
       "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -27164,27 +26420,23 @@
     },
     "node_modules/ganache-core/node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/regenerate": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/regenerator-runtime": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/regenerator-transform": {
       "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
+      "license": "BSD",
       "dependencies": {
         "babel-runtime": "^6.18.0",
         "babel-types": "^6.19.0",
@@ -27193,9 +26445,8 @@
     },
     "node_modules/ganache-core/node_modules/regex-not": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -27206,9 +26457,8 @@
     },
     "node_modules/ganache-core/node_modules/regexp.prototype.flags": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -27222,9 +26472,8 @@
     },
     "node_modules/ganache-core/node_modules/regexp.prototype.flags/node_modules/es-abstract": {
       "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -27247,9 +26496,8 @@
     },
     "node_modules/ganache-core/node_modules/regexpu-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha512-tJ9+S4oKjxY8IZ9jmjnp/mtytu1u3iyIQAfmI51IKWH6bFf7XR1ybtaO6j7INhZKXOTYADk7V5qxaqLkmNxiZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "regenerate": "^1.2.1",
         "regjsgen": "^0.2.0",
@@ -27258,15 +26506,13 @@
     },
     "node_modules/ganache-core/node_modules/regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha512-x+Y3yA24uF68m5GA+tBjbGYo64xXVJpbToBaWCoSNSc1hdk6dfctaRWrNFTVJZIIhL5GxW8zwjoixbnifnK59g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha512-jlQ9gYLfk2p3V5Ag5fYhA7fv7OHzd1KUH0PRP46xc3TgwjwgROIW572AfYg/X9kaNq/LJnu6oJcFRXlIrGoTRw==",
       "dev": true,
+      "license": "BSD",
       "dependencies": {
         "jsesc": "~0.5.0"
       },
@@ -27276,8 +26522,6 @@
     },
     "node_modules/ganache-core/node_modules/regjsparser/node_modules/jsesc": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
@@ -27285,27 +26529,24 @@
     },
     "node_modules/ganache-core/node_modules/repeat-element": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/ganache-core/node_modules/repeating": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-finite": "^1.0.0"
       },
@@ -27315,10 +26556,8 @@
     },
     "node_modules/ganache-core/node_modules/request": {
       "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -27347,16 +26586,13 @@
     },
     "node_modules/ganache-core/node_modules/resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/responselike": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "lowercase-keys": "^1.0.0"
@@ -27364,27 +26600,24 @@
     },
     "node_modules/ganache-core/node_modules/resumer": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "through": "~2.3.4"
       }
     },
     "node_modules/ganache-core/node_modules/ret": {
       "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12"
       }
     },
     "node_modules/ganache-core/node_modules/rimraf": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -27394,9 +26627,8 @@
     },
     "node_modules/ganache-core/node_modules/ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -27404,9 +26636,8 @@
     },
     "node_modules/ganache-core/node_modules/rlp": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.1"
       },
@@ -27416,14 +26647,11 @@
     },
     "node_modules/ganache-core/node_modules/rustbn.js": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
-      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
-      "dev": true
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)"
     },
     "node_modules/ganache-core/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -27438,44 +26666,39 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/safe-event-emitter": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
-      "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
-      "deprecated": "Renamed to @metamask/safe-event-emitter",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "events": "^3.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ret": "~0.1.10"
       }
     },
     "node_modules/ganache-core/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/scrypt-js": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/scryptsy": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
-      "integrity": "sha512-aldIRgMozSJ/Gl6K6qmJZysRP82lz83Wb42vl4PWN8SaLFHIaOzLPc9nUUW2jQN88CuGm5q5HefJ9jZ3nWSmTw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "pbkdf2": "^3.0.3"
@@ -27483,10 +26706,9 @@
     },
     "node_modules/ganache-core/node_modules/secp256k1": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -27498,14 +26720,11 @@
     },
     "node_modules/ganache-core/node_modules/seedrandom": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.1.tgz",
-      "integrity": "sha512-1/02Y/rUeU1CJBAGLebiC5Lbo5FnB22gQbIFFYTLkwvp1xdABZJH1sn4ZT1MzXmPpzv+Rf/Lu2NcsLJiK4rcDg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/semaphore": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -27513,9 +26732,8 @@
     },
     "node_modules/ganache-core/node_modules/send": {
       "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -27538,9 +26756,8 @@
     },
     "node_modules/ganache-core/node_modules/send/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -27548,23 +26765,20 @@
     },
     "node_modules/ganache-core/node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/send/node_modules/ms": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/serve-static": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "encodeurl": "~1.0.2",
@@ -27578,9 +26792,8 @@
     },
     "node_modules/ganache-core/node_modules/servify": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
-      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "body-parser": "^1.16.0",
@@ -27595,18 +26808,16 @@
     },
     "node_modules/ganache-core/node_modules/set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha512-Li5AOqrZWCVA2n5kryzEmqai6bKSIvpz5oUJHPVj6+dsbD3X1ixtsY5tEnsaNpH3pFAHmG8eIHUrtEtohrg+UQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/set-value": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -27619,9 +26830,8 @@
     },
     "node_modules/ganache-core/node_modules/set-value/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -27631,31 +26841,27 @@
     },
     "node_modules/ganache-core/node_modules/set-value/node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "dev": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -27666,8 +26872,6 @@
     },
     "node_modules/ganache-core/node_modules/simple-concat": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "dev": true,
       "funding": [
         {
@@ -27683,13 +26887,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/simple-get": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "decompress-response": "^3.3.0",
@@ -27699,9 +26903,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -27718,9 +26921,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -27732,9 +26934,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon-node/node_modules/define-property": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.0"
       },
@@ -27744,9 +26945,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.2.0"
       },
@@ -27756,15 +26956,13 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon-util/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/snapdragon-util/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -27774,18 +26972,16 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
       },
@@ -27795,9 +26991,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -27807,9 +27002,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -27819,9 +27013,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -27831,15 +27024,13 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -27849,9 +27040,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -27861,9 +27051,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -27875,43 +27064,37 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/kind-of": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
@@ -27922,9 +27105,8 @@
     },
     "node_modules/ganache-core/node_modules/source-map-support": {
       "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -27932,25 +27114,21 @@
     },
     "node_modules/ganache-core/node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha512-liJwHPI9x9d9w5WSIjM58MqGmmb7XzNqwdUA3kSBQ4lmDngexlKwawGzK3J1mKXi6+sysoMDlpVyZh9sv5vRfw==",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/split-string": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "extend-shallow": "^3.0.0"
       },
@@ -27960,9 +27138,8 @@
     },
     "node_modules/ganache-core/node_modules/sshpk": {
       "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -27974,26 +27151,19 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/sshpk/node_modules/tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/ganache-core/node_modules/static-extend": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -28004,9 +27174,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
       },
@@ -28016,9 +27185,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -28028,9 +27196,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -28040,15 +27207,13 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -28058,9 +27223,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -28070,9 +27234,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -28084,18 +27247,16 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/kind-of": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/statuses": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.6"
@@ -28103,9 +27264,8 @@
     },
     "node_modules/ganache-core/node_modules/stream-to-pull-stream": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "looper": "^3.0.0",
         "pull-stream": "^3.2.3"
@@ -28113,15 +27273,13 @@
     },
     "node_modules/ganache-core/node_modules/stream-to-pull-stream/node_modules/looper": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-      "integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -28129,24 +27287,21 @@
     },
     "node_modules/ganache-core/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/ganache-core/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/string.prototype.trim": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.3.tgz",
-      "integrity": "sha512-16IL9pIBA5asNOSukPfxX2W68BaBvxyiRK16H3RA/lWW9BDosh+w7f+LhomPHpXJ82QEe7w7/rY/S1CV97raLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -28161,9 +27316,8 @@
     },
     "node_modules/ganache-core/node_modules/string.prototype.trimend": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3"
@@ -28174,9 +27328,8 @@
     },
     "node_modules/ganache-core/node_modules/string.prototype.trimstart": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3"
@@ -28187,9 +27340,8 @@
     },
     "node_modules/ganache-core/node_modules/strip-hex-prefix": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0"
       },
@@ -28200,9 +27352,8 @@
     },
     "node_modules/ganache-core/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -28212,9 +27363,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js": {
       "version": "0.1.40",
-      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
-      "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bluebird": "^3.5.0",
@@ -28232,9 +27382,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/fs-extra": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -28244,9 +27393,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=4"
@@ -28254,9 +27402,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/got": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "decompress-response": "^3.2.0",
@@ -28280,9 +27427,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -28290,9 +27436,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/p-cancelable": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=4"
@@ -28300,9 +27445,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -28310,9 +27454,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha512-BVA4lR5PIviy2PMseNd2jbFQ+jwSwQGdJejf5ctd1rEXt0Ypd7yanUK9+lYechVlN5VaTJGsu2U/3MDDu6KgBA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "prepend-http": "^1.0.1"
@@ -28323,9 +27466,8 @@
     },
     "node_modules/ganache-core/node_modules/tape": {
       "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
-      "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-equal": "~1.1.1",
         "defined": "~1.0.0",
@@ -28349,9 +27491,8 @@
     },
     "node_modules/ganache-core/node_modules/tape/node_modules/glob": {
       "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -28369,9 +27510,8 @@
     },
     "node_modules/ganache-core/node_modules/tape/node_modules/is-regex": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -28384,18 +27524,16 @@
     },
     "node_modules/ganache-core/node_modules/tape/node_modules/object-inspect": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ganache-core/node_modules/tape/node_modules/resolve": {
       "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-parse": "^1.0.6"
       },
@@ -28405,9 +27543,8 @@
     },
     "node_modules/ganache-core/node_modules/tar": {
       "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
@@ -28424,9 +27561,8 @@
     },
     "node_modules/ganache-core/node_modules/tar/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
@@ -28434,9 +27570,8 @@
     },
     "node_modules/ganache-core/node_modules/tar/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
@@ -28445,15 +27580,13 @@
     },
     "node_modules/ganache-core/node_modules/through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/through2": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -28461,9 +27594,8 @@
     },
     "node_modules/ganache-core/node_modules/timed-out": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -28471,9 +27603,8 @@
     },
     "node_modules/ganache-core/node_modules/tmp": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "rimraf": "^2.6.3"
       },
@@ -28483,9 +27614,8 @@
     },
     "node_modules/ganache-core/node_modules/to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -28495,15 +27625,13 @@
     },
     "node_modules/ganache-core/node_modules/to-object-path/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/to-object-path/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -28513,9 +27641,8 @@
     },
     "node_modules/ganache-core/node_modules/to-readable-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=6"
@@ -28523,9 +27650,8 @@
     },
     "node_modules/ganache-core/node_modules/to-regex": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -28538,9 +27664,8 @@
     },
     "node_modules/ganache-core/node_modules/toidentifier": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.6"
@@ -28548,9 +27673,8 @@
     },
     "node_modules/ganache-core/node_modules/tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -28561,18 +27685,16 @@
     },
     "node_modules/ganache-core/node_modules/trim-right": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -28582,27 +27704,23 @@
     },
     "node_modules/ganache-core/node_modules/tweetnacl": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/ganache-core/node_modules/tweetnacl-util": {
       "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/ganache-core/node_modules/type": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "media-typer": "0.3.0",
@@ -28614,59 +27732,51 @@
     },
     "node_modules/ganache-core/node_modules/typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/typewise": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "typewise-core": "^1.2.0"
       }
     },
     "node_modules/ganache-core/node_modules/typewise-core": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/typewiselite": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-      "integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ultron": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/underscore": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/union-value": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -28679,36 +27789,32 @@
     },
     "node_modules/ganache-core/node_modules/union-value/node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/unorm": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
       "dev": true,
+      "license": "MIT or GPL-2.0",
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/ganache-core/node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.8"
@@ -28716,9 +27822,8 @@
     },
     "node_modules/ganache-core/node_modules/unset-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -28729,9 +27834,8 @@
     },
     "node_modules/ganache-core/node_modules/unset-value/node_modules/has-value": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-value": "^2.0.3",
         "has-values": "^0.1.4",
@@ -28743,9 +27847,8 @@
     },
     "node_modules/ganache-core/node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isarray": "1.0.0"
       },
@@ -28755,34 +27858,29 @@
     },
     "node_modules/ganache-core/node_modules/unset-value/node_modules/has-values": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/ganache-core/node_modules/urix": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
-      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/url-parse-lax": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "prepend-http": "^2.0.0"
@@ -28793,16 +27891,14 @@
     },
     "node_modules/ganache-core/node_modules/url-set-query": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-      "integrity": "sha512-3AChu4NiXquPfeckE5R5cGdiHCMWJx1dwCWOmWIL4KHAziJNOFIYJlpGFeKDvwLPHovZRCxK3cYlwzqI9Vp+Gg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/url-to-options": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha512-0kQLIzG4fdk/G5NONku64rSH/x32NOA39LVQqlK8Le6lvTF6GGRJpqaQFGgU+CLwySIqBSMdwYM0sYcW9f6P4A==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 4"
@@ -28810,41 +27906,36 @@
     },
     "node_modules/ganache-core/node_modules/use": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ganache-core/node_modules/utf-8-validate": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
-      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }
     },
     "node_modules/ganache-core/node_modules/utf8": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/util.promisify": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.1.tgz",
-      "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -28858,9 +27949,8 @@
     },
     "node_modules/ganache-core/node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.4.0"
@@ -28868,26 +27958,22 @@
     },
     "node_modules/ganache-core/node_modules/uuid": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
       }
     },
     "node_modules/ganache-core/node_modules/varint": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.8"
@@ -28895,12 +27981,11 @@
     },
     "node_modules/ganache-core/node_modules/verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -28909,10 +27994,9 @@
     },
     "node_modules/ganache-core/node_modules/web3": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.11.tgz",
-      "integrity": "sha512-mjQ8HeU41G6hgOYm1pmeH0mRAeNKJGnJEUzDMoerkpw7QUQT4exVREgF1MYPvL/z6vAshOXei25LE/t/Bxl8yQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "web3-bzz": "1.2.11",
@@ -28929,9 +28013,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-bzz": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.11.tgz",
-      "integrity": "sha512-XGpWUEElGypBjeFyUhTkiPXFbDVD6Nr/S5jznE3t8cWUA0FxRf1n3n/NuIZeb0H9RkN2Ctd/jNma/k8XGa3YKg==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "@types/node": "^12.12.6",
@@ -28945,16 +28028,14 @@
     },
     "node_modules/ganache-core/node_modules/web3-bzz/node_modules/@types/node": {
       "version": "12.19.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
-      "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/web3-core": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
-      "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "@types/bn.js": "^4.11.5",
@@ -28971,9 +28052,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-helpers": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
-      "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "underscore": "1.9.1",
@@ -28986,9 +28066,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-method": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
-      "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "@ethersproject/transactions": "^5.0.0-beta.135",
@@ -29004,9 +28083,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-promievent": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
-      "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "eventemitter3": "4.0.4"
@@ -29017,9 +28095,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-requestmanager": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
-      "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "underscore": "1.9.1",
@@ -29034,9 +28111,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-subscriptions": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
-      "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "eventemitter3": "4.0.4",
@@ -29049,16 +28125,14 @@
     },
     "node_modules/ganache-core/node_modules/web3-core/node_modules/@types/node": {
       "version": "12.19.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
-      "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/web3-eth": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.11.tgz",
-      "integrity": "sha512-REvxW1wJ58AgHPcXPJOL49d1K/dPmuw4LjPLBPStOVkQjzDTVmJEIsiLwn2YeuNDd4pfakBwT8L3bz1G1/wVsQ==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "underscore": "1.9.1",
@@ -29081,9 +28155,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-abi": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
-      "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "@ethersproject/abi": "5.0.0-beta.153",
@@ -29096,9 +28169,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-accounts": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.11.tgz",
-      "integrity": "sha512-6FwPqEpCfKIh3nSSGeo3uBm2iFSnFJDfwL3oS9pyegRBXNsGRVpgiW63yhNzL0796StsvjHWwQnQHsZNxWAkGw==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "crypto-browserify": "3.12.0",
@@ -29119,9 +28191,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-accounts/node_modules/eth-lib": {
       "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "^4.11.6",
@@ -29131,10 +28202,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-accounts/node_modules/uuid": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -29142,9 +28211,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-contract": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
-      "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "@types/bn.js": "^4.11.5",
@@ -29163,9 +28231,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-ens": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.11.tgz",
-      "integrity": "sha512-dbW7dXP6HqT1EAPvnniZVnmw6TmQEKF6/1KgAxbo8iBBYrVTMDGFQUUnZ+C4VETGrwwaqtX4L9d/FrQhZ6SUiA==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "content-hash": "^2.5.2",
@@ -29184,9 +28251,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-iban": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
-      "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -29198,9 +28264,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-personal": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
-      "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "@types/node": "^12.12.6",
@@ -29216,16 +28281,14 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-personal/node_modules/@types/node": {
       "version": "12.19.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
-      "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/web3-net": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
-      "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "web3-core": "1.2.11",
@@ -29238,9 +28301,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine": {
       "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.2.1.tgz",
-      "integrity": "sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async": "^2.5.0",
         "backoff": "^2.5.0",
@@ -29248,7 +28310,7 @@
         "cross-fetch": "^2.1.0",
         "eth-block-tracker": "^3.0.0",
         "eth-json-rpc-infura": "^3.1.0",
-        "eth-sig-util": "^1.4.2",
+        "eth-sig-util": "3.0.0",
         "ethereumjs-block": "^1.2.2",
         "ethereumjs-tx": "^1.2.0",
         "ethereumjs-util": "^5.1.5",
@@ -29266,64 +28328,33 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/abstract-leveldown": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/deferred-leveldown": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
       }
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/eth-sig-util": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
-      "integrity": "sha512-iNZ576iTOGcfllftB73cPB5AN+XUQAT/T8xzsILsghXC1o8gJUqe3RHlcDqagu+biFpYQ61KQrZZJza8eRSYqw==",
-      "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       }
     },
-    "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-abi": {
-      "version": "0.6.8",
-      "resolved": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-      "integrity": "sha512-qs8G5KwnIO/thOQjv1RvR/4oiTsy6IaCsN+ory5dbiqFXz8sd239aWJH0wmsVNPimL5X1KzQheUpi6xAo6FU4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      }
-    },
-    "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-      "dev": true,
-      "dependencies": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
-      }
-    },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-account": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
-      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-util": "^5.0.0",
         "rlp": "^2.0.0",
@@ -29332,10 +28363,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-block": {
       "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
-      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
         "ethereum-common": "0.2.0",
@@ -29346,16 +28375,13 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-block/node_modules/ethereum-common": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-tx": {
       "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereum-common": "^0.0.18",
         "ethereumjs-util": "^5.0.0"
@@ -29363,9 +28389,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -29378,10 +28403,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
-      "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/vm. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
         "async-eventemitter": "^0.2.2",
@@ -29398,10 +28421,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm/node_modules/ethereumjs-block": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
-      "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-      "deprecated": "New package name format for new versions: @ethereumjs/block. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
         "ethereumjs-common": "^1.5.0",
@@ -29412,9 +28433,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm/node_modules/ethereumjs-block/node_modules/ethereumjs-util": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -29427,10 +28447,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm/node_modules/ethereumjs-tx": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "deprecated": "New package name format for new versions: @ethereumjs/tx. Please update.",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
         "ethereumjs-util": "^6.0.0"
@@ -29438,9 +28456,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm/node_modules/ethereumjs-util": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -29453,30 +28470,26 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-codec": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-errors": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
       }
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha512-1qua0RHNtr4nrZBgYlpV0qHHeHpcRRWTxEZJ8xsemoHAXNL5tbooh4tPEEqIqsbWCAJBmUmkwYK/sW5OrFjWWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "level-errors": "^1.0.3",
@@ -29486,9 +28499,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -29498,9 +28510,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-ws": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-      "integrity": "sha512-XUTaO/+Db51Uiyp/t7fCMGVFOTdtLS/NIACxE/GHsij15mKzxksZifKVjlXDF41JMUP/oM1Oc4YNGdKnc3dVLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
         "xtend": "~2.1.1"
@@ -29508,9 +28519,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -29520,8 +28530,6 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
       "dev": true,
       "dependencies": {
         "object-keys": "~0.4.0"
@@ -29532,9 +28540,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/levelup": {
       "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
         "level-codec": "~7.0.0",
@@ -29547,15 +28554,13 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ltgt": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/memdown": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha512-iVrGHZB8i4OQfM155xx8akvG9FIj+ht14DX5CQkCTG4EHzZ3d3sgckIf/Lm9ivZalEsFuEVnWv2B2WZvbrro2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
         "functional-red-black-tree": "^1.0.1",
@@ -29567,18 +28572,16 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
         "ethereumjs-util": "^5.0.0",
@@ -29592,51 +28595,44 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/object-keys": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/semver": {
       "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ws": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/web3-providers-http": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
-      "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "web3-core-helpers": "1.2.11",
@@ -29648,9 +28644,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-providers-ipc": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
-      "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "oboe": "2.1.4",
@@ -29663,9 +28658,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-providers-ws": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
-      "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "eventemitter3": "4.0.4",
@@ -29679,9 +28673,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-shh": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.11.tgz",
-      "integrity": "sha512-B3OrO3oG1L+bv3E1sTwCx66injW1A8hhwpknDUbV+sw3fehFazA06z9SGXUefuFI1kVs4q2vRi0n4oCcI4dZDg==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "web3-core": "1.2.11",
@@ -29695,9 +28688,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-utils": {
       "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
-      "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
       "dev": true,
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -29715,9 +28707,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-utils/node_modules/eth-lib": {
       "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bn.js": "^4.11.6",
@@ -29727,9 +28718,8 @@
     },
     "node_modules/ganache-core/node_modules/websocket": {
       "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
-      "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
@@ -29744,36 +28734,31 @@
     },
     "node_modules/ganache-core/node_modules/websocket/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/ganache-core/node_modules/websocket/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/ws": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "async-limiter": "~1.0.0",
@@ -29783,16 +28768,14 @@
     },
     "node_modules/ganache-core/node_modules/ws/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/xhr": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "global": "~4.4.0",
         "is-function": "^1.0.1",
@@ -29802,9 +28785,8 @@
     },
     "node_modules/ganache-core/node_modules/xhr-request": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
-      "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "buffer-to-arraybuffer": "^0.0.5",
@@ -29818,9 +28800,8 @@
     },
     "node_modules/ganache-core/node_modules/xhr-request-promise": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
-      "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "xhr-request": "^1.1.0"
@@ -29828,9 +28809,8 @@
     },
     "node_modules/ganache-core/node_modules/xhr2-cookies": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-      "integrity": "sha512-hjXUA6q+jl/bd8ADHcVfFsSPIf+tyLIjuO9TwJC9WI6JP2zKcS7C+p56I9kCLLsaCiNT035iYvEUUzdEFj/8+g==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "cookiejar": "^2.1.1"
@@ -29838,27 +28818,24 @@
     },
     "node_modules/ganache-core/node_modules/xtend": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/ganache-core/node_modules/yaeti": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.32"
       }
     },
     "node_modules/ganache-core/node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -35247,7 +34224,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
       "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -39458,7 +38435,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
       "integrity": "sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"

--- a/nitro-protocol/package.json
+++ b/nitro-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/nitro-protocol",
-  "version": "2.0.0-alpha.4-ts-port-0.1.1",
+  "version": "2.0.0-alpha.4-ts-port-0.1.2",
   "author": "statechannels.org",
   "bugs": "https://github.com/statechannels/go-nitro/issues",
   "description": "Smart contracts and typescript libraries for nitro state channel protocol.",


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

Contains fix for failing CI by downgrading Node version

Reference: https://github.com/NomicFoundation/hardhat/issues/3877