### PR TITLE
Use slog in receivePeerInfo and revert use of mplex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	github.com/libp2p/go-libp2p-asn-util v0.3.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.6.3 // indirect
 	github.com/libp2p/go-libp2p-record v0.2.0 // indirect
-	github.com/libp2p/go-mplex v0.7.0 // indirect
 	github.com/libp2p/go-msgio v0.3.0 // indirect
 	github.com/libp2p/go-nat v0.2.0 // indirect
 	github.com/libp2p/go-netroute v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -495,8 +495,6 @@ github.com/libp2p/go-libp2p-record v0.2.0 h1:oiNUOCWno2BFuxt3my4i1frNrt7PerzB3qu
 github.com/libp2p/go-libp2p-record v0.2.0/go.mod h1:I+3zMkvvg5m2OcSdoL0KPljyJyvNDFGKX7QdlpYUcwk=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
-github.com/libp2p/go-mplex v0.7.0 h1:BDhFZdlk5tbr0oyFq/xv/NPGfjbnrsDam1EvutpBDbY=
-github.com/libp2p/go-mplex v0.7.0/go.mod h1:rW8ThnRcYWft/Jb2jeORBmPd6xuG3dGxWN/W168L9EU=
 github.com/libp2p/go-msgio v0.3.0 h1:mf3Z8B1xcFN314sWX+2vOTShIE0Mmn2TXn3YCUQGNj0=
 github.com/libp2p/go-msgio v0.3.0/go.mod h1:nyRM819GmVaF9LX3l03RMh10QdOroF++NBbxAb0mmDM=
 github.com/libp2p/go-nat v0.2.0 h1:Tyz+bUFAYqGyJ/ppPPymMGbIgNRH+WqC5QrT5fKrrGk=

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -239,7 +239,7 @@ func (ms *P2PMessageService) msgStreamHandler(stream network.Stream) {
 
 // receivePeerInfo receives peer info from the given stream
 func (ms *P2PMessageService) receivePeerInfo(stream network.Stream) {
-	ms.logger.Debug().Msgf("received peerInfo")
+	ms.logger.Info("received peerInfo")
 	defer stream.Close()
 
 	// Create a buffer stream for non blocking read and write.
@@ -251,21 +251,21 @@ func (ms *P2PMessageService) receivePeerInfo(stream network.Stream) {
 		return
 	}
 	if err != nil {
-		ms.logger.Err(err)
+		ms.logger.Error("error", "err", err)
 		return
 	}
 
 	var msg *basicPeerInfo
 	err = json.Unmarshal([]byte(raw), &msg)
 	if err != nil {
-		ms.logger.Err(err)
+		ms.logger.Error("error in unmarshalling", "err", err)
 		return
 	}
 
 	_, foundPeer := ms.peers.LoadOrStore(msg.Address.String(), msg.Id)
 	if !foundPeer {
 		peerInfo := basicPeerInfo{msg.Id, msg.Address}
-		ms.logger.Debug().Msgf("stored new peer in map: %v", peerInfo)
+		ms.logger.Info("stored new peer in map: %v", peerInfo)
 		ms.newPeerInfo <- peerInfo
 	}
 }

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	"github.com/libp2p/go-libp2p/p2p/muxer/mplex"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	"github.com/libp2p/go-libp2p/p2p/transport/websocket"
 	"github.com/multiformats/go-multiaddr"
@@ -95,7 +94,7 @@ func NewMessageService(ip string, tcpPort int, wsPort int, me types.Address, pk 
 		libp2p.EnableNATService(),
 		libp2p.Transport(websocket.New),
 		// libp2p.NoSecurity, // Use default security options (Noise + TLS)
-		libp2p.Muxer(mplex.ID, mplex.DefaultTransport),
+		libp2p.DefaultMuxers,
 	}
 	host, err := libp2p.New(options...)
 	if err != nil {

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -264,7 +264,7 @@ func (ms *P2PMessageService) receivePeerInfo(stream network.Stream) {
 	_, foundPeer := ms.peers.LoadOrStore(msg.Address.String(), msg.Id)
 	if !foundPeer {
 		peerInfo := basicPeerInfo{msg.Id, msg.Address}
-		ms.logger.Info("stored new peer in map: %v", peerInfo)
+		ms.logger.Info("stored new peer in map", "peerInfo", peerInfo)
 		ms.newPeerInfo <- peerInfo
 	}
 }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Use slog in receivePeerInfo method that was added back to connect with ts-nitro
- Revert commit to add mplex as it is deprecated
  - Using yamux in ts-nitro for libp2p connection