### PR TITLE
Add WebSocket message port in InitializeNode method

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -16,7 +16,7 @@ import (
 )
 
 func InitializeNode(pkString string, chainOpts chain.ChainOpts,
-	useDurableStore bool, durableStoreFolder string, msgPort int, bootPeers []string,
+	useDurableStore bool, durableStoreFolder string, msgPort int, wsMsgPort int, bootPeers []string,
 ) (*node.Node, *store.Store, *p2pms.P2PMessageService, *chainservice.EthChainService, error) {
 	if pkString == "" {
 		panic("pk must be set")
@@ -29,7 +29,7 @@ func InitializeNode(pkString string, chainOpts chain.ChainOpts,
 	}
 
 	slog.Info("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
-	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, bootPeers)
+	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, wsMsgPort, *ourStore.GetAddress(), pk, bootPeers)
 
 	slog.Info("Initializing chain service and connecting to " + chainOpts.ChainUrl + "...")
 	ourChain, err := chain.InitializeEthChainService(chainOpts)

--- a/nitro-protocol/package-lock.json
+++ b/nitro-protocol/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cerc-io/nitro-protocol",
-  "version": "2.0.0-alpha.4-ts-port-0.1.1",
+  "version": "2.0.0-alpha.4-ts-port-0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cerc-io/nitro-protocol",
-      "version": "2.0.0-alpha.4-ts-port-0.1.1",
+      "version": "2.0.0-alpha.4-ts-port-0.1.3",
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/contracts": "^4.7.3",
@@ -54,6 +54,9 @@
         "typechain": "^8.0.0",
         "typescript": "^4.6.3",
         "wait-on": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/nitro-protocol/package.json
+++ b/nitro-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/nitro-protocol",
-  "version": "2.0.0-alpha.4-ts-port-0.1.2",
+  "version": "2.0.0-alpha.4-ts-port-0.1.3",
   "author": "statechannels.org",
   "bugs": "https://github.com/statechannels/go-nitro/issues",
   "description": "Smart contracts and typescript libraries for nitro state channel protocol.",


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Add WebSocket message port in `initializeNode` method
- Upgrade `nitro-protocol` package version after contract changes