### PR TITLE
Disable compression in payment proxy transport and add proxy in the Dockerfile

### DIFF
--- a/cmd/start-reverse-payment-proxy/main.go
+++ b/cmd/start-reverse-payment-proxy/main.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	NITRO_ENDPOINT     = "nitroendpoint"
-	PROXY_ADDRESS      = "proxyaddress"
-	DESTINATION_URL    = "destinationurl"
-	COST_PER_BYTE      = "costperbyte"
-	FILTER_RPC_METHODS = "filterrpcmethods"
+	NITRO_ENDPOINT          = "nitroendpoint"
+	PROXY_ADDRESS           = "proxyaddress"
+	DESTINATION_URL         = "destinationurl"
+	COST_PER_BYTE           = "costperbyte"
+	ENABLE_PAID_RPC_METHODS = "enablepaidrpcmethods"
 )
 
 func main() {
@@ -50,8 +50,8 @@ func main() {
 				Aliases: []string{"c"},
 			},
 			&cli.BoolFlag{
-				Name:    FILTER_RPC_METHODS,
-				Usage:   "Flag to enable/disable filtering RPC methods that require payment",
+				Name:    ENABLE_PAID_RPC_METHODS,
+				Usage:   "Flag to enable/disable payment for RPC methods",
 				Value:   false,
 				Aliases: []string{"r"},
 			},
@@ -67,7 +67,7 @@ func main() {
 				nitroEndpoint,
 				c.String(DESTINATION_URL),
 				c.Uint64(COST_PER_BYTE),
-				c.Bool(FILTER_RPC_METHODS),
+				c.Bool(ENABLE_PAID_RPC_METHODS),
 			)
 
 			return rProxy.Start()

--- a/cmd/start-reverse-payment-proxy/main.go
+++ b/cmd/start-reverse-payment-proxy/main.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	NITRO_ENDPOINT  = "nitroendpoint"
-	PROXY_ADDRESS   = "proxyaddress"
-	DESTINATION_URL = "destinationurl"
-	COST_PER_BYTE   = "costperbyte"
+	NITRO_ENDPOINT     = "nitroendpoint"
+	PROXY_ADDRESS      = "proxyaddress"
+	DESTINATION_URL    = "destinationurl"
+	COST_PER_BYTE      = "costperbyte"
+	FILTER_RPC_METHODS = "filterrpcmethods"
 )
 
 func main() {
@@ -48,6 +49,12 @@ func main() {
 				Value:   1,
 				Aliases: []string{"c"},
 			},
+			&cli.BoolFlag{
+				Name:    FILTER_RPC_METHODS,
+				Usage:   "Flag to enable/disable filtering RPC methods that require payment",
+				Value:   false,
+				Aliases: []string{"r"},
+			},
 		},
 		Action: func(c *cli.Context) error {
 			proxyEndpoint := c.String(PROXY_ADDRESS)
@@ -60,6 +67,7 @@ func main() {
 				nitroEndpoint,
 				c.String(DESTINATION_URL),
 				c.Uint64(COST_PER_BYTE),
+				c.Bool(FILTER_RPC_METHODS),
 			)
 
 			return rProxy.Start()

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -15,6 +15,6 @@ COPY --from=builder /app/nitro .
 COPY --from=builder /app/start-reverse-payment-proxy .
 COPY --from=builder /app/config.toml .
 
-EXPOSE 3005 4005
+EXPOSE 3005 4005 5005
 
 CMD ["./nitro", "--config", "./config.toml"]

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -8,7 +8,7 @@ RUN go build -v -o start-reverse-payment-proxy ./cmd/start-reverse-payment-proxy
 
 FROM debian:bullseye-slim
 RUN apt-get update
-RUN apt-get install -y ca-certificates jq
+RUN apt-get install -y ca-certificates jq netcat
 RUN rm -rf /var/lib/apt/lists/*
 WORKDIR /app/
 COPY --from=builder /app/nitro .

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -6,7 +6,7 @@ RUN go build -v -o nitro .
 
 FROM debian:bullseye-slim
 RUN apt-get update
-RUN apt-get install -y ca-certificates
+RUN apt-get install -y ca-certificates jq
 RUN rm -rf /var/lib/apt/lists/*
 WORKDIR /app/
 COPY --from=builder /app/nitro .

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -2,7 +2,9 @@ FROM golang:1.21-bullseye AS builder
 WORKDIR /app
 COPY . .
 COPY ./docker/local/config.toml .
+
 RUN go build -v -o nitro .
+RUN go build -v -o start-reverse-payment-proxy ./cmd/start-reverse-payment-proxy
 
 FROM debian:bullseye-slim
 RUN apt-get update
@@ -10,6 +12,7 @@ RUN apt-get install -y ca-certificates jq
 RUN rm -rf /var/lib/apt/lists/*
 WORKDIR /app/
 COPY --from=builder /app/nitro .
+COPY --from=builder /app/start-reverse-payment-proxy .
 COPY --from=builder /app/config.toml .
 
 EXPOSE 3005 4005

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -29,7 +29,7 @@ func InitializeNode(pkString string, chainOpts chain.ChainOpts,
 	}
 
 	slog.Info("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
-	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, wsMsgPort, *ourStore.GetAddress(), pk, bootPeers)
+	messageService := p2pms.NewMessageService("0.0.0.0", msgPort, wsMsgPort, *ourStore.GetAddress(), pk, bootPeers)
 
 	slog.Info("Initializing chain service and connecting to " + chainOpts.ChainUrl + "...")
 	ourChain, err := chain.InitializeEthChainService(chainOpts)

--- a/node_test/reverseproxy_test.go
+++ b/node_test/reverseproxy_test.go
@@ -80,7 +80,8 @@ func TestReversePaymentProxy(t *testing.T) {
 		proxyAddress,
 		bobRPCUrl,
 		destinationServerUrl,
-		1)
+		1,
+		false)
 	defer func() {
 		err := proxy.Stop()
 		if err != nil {

--- a/reverseproxy/proxy.go
+++ b/reverseproxy/proxy.go
@@ -31,6 +31,12 @@ const (
 	ErrPayment = types.ConstError("payment error")
 )
 
+var paidRPCMethods = []string{
+	"eth_getLogs",
+	"eth_getStorageAt",
+	"eth_getBlockByHash",
+}
+
 // createPaymentError wraps an error with ErrPayment.
 func createPaymentError(err error) error {
 	return fmt.Errorf("%w: %w", ErrPayment, err)
@@ -86,16 +92,28 @@ func NewReversePaymentProxy(proxyAddress string, nitroEndpoint string, destinati
 // It then delegates to the reverse proxy to handle rewriting the request and sending it to the destination
 func (p *ReversePaymentProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	enableCORS(w, r)
-	v, err := parseVoucher(r.URL.Query())
-	if err != nil {
-		p.handleError(w, r, createPaymentError(fmt.Errorf("could not parse voucher: %w", err)))
-		return
+
+	queryParams := r.URL.Query()
+	rpcMethod := queryParams.Get("method")
+
+	// Check if payment is required for RPC method
+	// TODO: Check RPC method in request body
+	for _, paidRPCMethod := range paidRPCMethods {
+		if paidRPCMethod == rpcMethod {
+			v, err := parseVoucher(queryParams)
+			if err != nil {
+				p.handleError(w, r, createPaymentError(fmt.Errorf("could not parse voucher: %w", err)))
+				return
+			}
+
+			removeVoucher(r)
+
+			// We add the voucher to the request context so we can access it in the response handler
+			r = r.WithContext(context.WithValue(r.Context(), VOUCHER_CONTEXT_ARG, v))
+
+			break
+		}
 	}
-
-	removeVoucher(r)
-
-	// We add the voucher to the request context so we can access it in the response handler
-	r = r.WithContext(context.WithValue(r.Context(), VOUCHER_CONTEXT_ARG, v))
 
 	p.reverseProxy.ServeHTTP(w, r)
 }
@@ -116,7 +134,8 @@ func (p *ReversePaymentProxy) handleDestinationResponse(r *http.Response) error 
 
 	v, ok := r.Request.Context().Value(VOUCHER_CONTEXT_ARG).(payments.Voucher)
 	if !ok {
-		return createPaymentError(fmt.Errorf("could not fetch voucher from context"))
+		// If VOUCHER_CONTEXT_ARG does not exist the request does not need payment
+		return nil
 	}
 	cost := p.costPerByte * contentLength
 

--- a/reverseproxy/proxy.go
+++ b/reverseproxy/proxy.go
@@ -70,6 +70,11 @@ func NewReversePaymentProxy(proxyAddress string, nitroEndpoint string, destinati
 	p.reverseProxy.Rewrite = func(pr *httputil.ProxyRequest) { pr.SetURL(p.destinationUrl) }
 	p.reverseProxy.ModifyResponse = p.handleDestinationResponse
 	p.reverseProxy.ErrorHandler = p.handleError
+
+	// Setup transport with compression disabled to access content-length header in handleDestinationResponse
+	p.reverseProxy.Transport = http.DefaultTransport
+	p.reverseProxy.Transport.(*http.Transport).DisableCompression = true
+
 	// Wire up our handler to the server
 	p.server.Handler = p
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Disable compression on reverse proxy transport to access content-length
- Add `jq`, `netcat` to the Docker image
- Add binary for reverse payment proxy to the Docker image
- Listen on `0.0.0.0` for Message service ports
- Add flag `enablepaidrpcmethods` to verify payments for selected RPC methods
- Following TODOs will be addressed in follow on PRs:
  - Add util package to parse RPC method from request body
    - Get RPC methods from config
  - Fix for checking `Content-Length` header in payment proxy