### PR TITLE
Changes required for running proxy server and `nitro-rpc-client` in payments stack

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: "18.15.0"
       - name: "Install dependencies and build packages"
         run: |
-          cd ./nitro-protocol
+          cd ./packages/nitro-protocol
           npm ci --legacy-peer-deps
       - name: Configure git.vdb.to npm registry
         run: |

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 COPY ./docker/local/config.toml .
 
 RUN go build -v -o nitro .
-RUN go build -v -o start-reverse-payment-proxy ./cmd/start-reverse-payment-proxy
+RUN go build -v -o proxy ./cmd/start-payment-proxy
 
 FROM debian:bullseye-slim
 RUN apt-get update
@@ -12,7 +12,7 @@ RUN apt-get install -y ca-certificates jq netcat
 RUN rm -rf /var/lib/apt/lists/*
 WORKDIR /app/
 COPY --from=builder /app/nitro .
-COPY --from=builder /app/start-reverse-payment-proxy .
+COPY --from=builder /app/proxy .
 COPY --from=builder /app/config.toml .
 
 EXPOSE 3005 4005 5005

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -6,7 +6,7 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 
 import { NitroRpcClient } from "./rpc-client";
-import { compactJson, getLocalRPCUrl, logOutChannelUpdates } from "./utils";
+import { compactJson, getCustomRPCUrl, logOutChannelUpdates } from "./utils";
 
 yargs(hideBin(process.argv))
   .scriptName("nitro-rpc-client")
@@ -18,6 +18,12 @@ yargs(hideBin(process.argv))
       type: "boolean",
       description: "Whether channel notifications are printed to the console",
     },
+    h: {
+      alias: "host",
+      default: "127.0.0.1",
+      type: "string",
+      description: "Custom hostname",
+    },
   })
   .command(
     "version",
@@ -25,9 +31,10 @@ yargs(hideBin(process.argv))
     async () => {},
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       const version = await rpcClient.GetVersion();
       console.log(version);
@@ -41,9 +48,10 @@ yargs(hideBin(process.argv))
     async () => {},
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       const address = await rpcClient.GetAddress();
       console.log(address);
@@ -57,9 +65,10 @@ yargs(hideBin(process.argv))
     async () => {},
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       const ledgers = await rpcClient.GetAllLedgerChannels();
       for (const ledger of ledgers) {
@@ -82,9 +91,10 @@ yargs(hideBin(process.argv))
 
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       const paymentChans = await rpcClient.GetPaymentChannelsByLedger(
         yargs.ledgerId
@@ -115,9 +125,10 @@ yargs(hideBin(process.argv))
     },
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
 
@@ -146,9 +157,10 @@ yargs(hideBin(process.argv))
     },
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
 
@@ -179,9 +191,10 @@ yargs(hideBin(process.argv))
     },
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
 
@@ -220,9 +233,10 @@ yargs(hideBin(process.argv))
     },
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
 
       if (yargs.n) logOutChannelUpdates(rpcClient);
@@ -248,9 +262,10 @@ yargs(hideBin(process.argv))
     },
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
 
       const ledgerInfo = await rpcClient.GetLedgerChannel(yargs.channelId);
@@ -271,9 +286,10 @@ yargs(hideBin(process.argv))
     },
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       const paymentChannelInfo = await rpcClient.GetPaymentChannel(
         yargs.channelId
@@ -301,9 +317,10 @@ yargs(hideBin(process.argv))
     },
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
 
@@ -334,9 +351,10 @@ yargs(hideBin(process.argv))
     },
     async (yargs) => {
       const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
 
       const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
-        getLocalRPCUrl(rpcPort)
+        getCustomRPCUrl(rpcHost, rpcPort)
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
 

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -88,6 +88,10 @@ export function getLocalRPCUrl(port: number): string {
   return `127.0.0.1:${port}/${RPC_PATH}`;
 }
 
+export function getCustomRPCUrl(host: string, port: number): string {
+  return `${host}:${port}/${RPC_PATH}`;
+}
+
 export async function logOutChannelUpdates(rpcClient: NitroRpcClient) {
   const shortAddress = (await rpcClient.GetAddress()).slice(0, 8);
 

--- a/paymentproxy/proxy.go
+++ b/paymentproxy/proxy.go
@@ -36,6 +36,7 @@ var paidRPCMethods = []string{
 	"eth_getLogs",
 	"eth_getStorageAt",
 	"eth_getBlockByHash",
+	"eth_getBlockByNumber",
 }
 
 // createPaymentError wraps an error with ErrPayment.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,6 +1876,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cerc-io/nitro-protocol@workspace:packages/nitro-protocol":
+  version: 0.0.0-use.local
+  resolution: "@cerc-io/nitro-protocol@workspace:packages/nitro-protocol"
+  dependencies:
+    "@nomicfoundation/hardhat-network-helpers": ^1.0.3
+    "@nomiclabs/hardhat-ethers": ^2.1.1
+    "@nomiclabs/hardhat-etherscan": ^3.0.0
+    "@nomiclabs/hardhat-waffle": ^2.0.2
+    "@openzeppelin/contracts": ^4.7.3
+    "@statechannels/devtools": ^0.5.7
+    "@statechannels/exit-format": ^0.2.0
+    "@typechain/ethers-v5": ^9.0.0
+    "@typechain/hardhat": ^4.0.0
+    "@types/jest": 29.5.0
+    "@types/lodash.isequal": ^4.5.5
+    "@types/lodash.shuffle": ^4.2.6
+    "@types/mocha": ^9.1.0
+    "@types/node": ^18.11.3
+    "@types/wait-on": ^5.3.1
+    "@typescript-eslint/eslint-plugin": ^5.59.0
+    "@typescript-eslint/parser": ^5.59.0
+    axios: 0.25.0
+    chai: ^4.3.6
+    dotenv: ^14.3.2
+    eslint: 7.17.0
+    eslint-config-prettier: ^8.5.0
+    eslint-plugin-import: ^2.26.0
+    eslint-plugin-prettier: 3.3.1
+    ethereum-waffle: ^3.4.0
+    ethers: ^5.5.4
+    hardhat: ^2.17.2
+    hardhat-deploy: ^0.10.4
+    hardhat-deploy-ethers: ^0.3.0-beta.13
+    hardhat-gas-reporter: ^1.0.7
+    hardhat-watcher: ^2.3.0
+    jest: 29.5.0
+    lodash.isequal: ^4.5.0
+    lodash.shuffle: ^4.2.0
+    prettier: ^2.6.2
+    prettier-plugin-solidity: ^1.0.0-beta.19
+    solhint: ^3.3.7
+    solidity-coverage: ^0.8.4
+    ts-jest: 29.1.0
+    ts-node: ^10.4.0
+    typechain: ^8.0.0
+    typescript: ^4.6.3
+    wait-on: ^6.0.1
+  languageName: unknown
+  linkType: soft
+
 "@chainsafe/as-sha256@npm:^0.3.1":
   version: 0.3.1
   resolution: "@chainsafe/as-sha256@npm:0.3.1"
@@ -4478,56 +4528,6 @@ __metadata:
   checksum: 4342bb6a836b5844c8dcdc8933ed12a8e058e41fddbb2b4a95ab615979dd52a15448bce4640550204c2e103bec3de52ccbc1f3a4a3cb2696906cd3ce50980cb1
   languageName: node
   linkType: hard
-
-"@statechannels/nitro-protocol@workspace:packages/nitro-protocol":
-  version: 0.0.0-use.local
-  resolution: "@statechannels/nitro-protocol@workspace:packages/nitro-protocol"
-  dependencies:
-    "@nomicfoundation/hardhat-network-helpers": ^1.0.3
-    "@nomiclabs/hardhat-ethers": ^2.1.1
-    "@nomiclabs/hardhat-etherscan": ^3.0.0
-    "@nomiclabs/hardhat-waffle": ^2.0.2
-    "@openzeppelin/contracts": ^4.7.3
-    "@statechannels/devtools": ^0.5.7
-    "@statechannels/exit-format": ^0.2.0
-    "@typechain/ethers-v5": ^9.0.0
-    "@typechain/hardhat": ^4.0.0
-    "@types/jest": 29.5.0
-    "@types/lodash.isequal": ^4.5.5
-    "@types/lodash.shuffle": ^4.2.6
-    "@types/mocha": ^9.1.0
-    "@types/node": ^18.11.3
-    "@types/wait-on": ^5.3.1
-    "@typescript-eslint/eslint-plugin": ^5.59.0
-    "@typescript-eslint/parser": ^5.59.0
-    axios: 0.25.0
-    chai: ^4.3.6
-    dotenv: ^14.3.2
-    eslint: 7.17.0
-    eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.26.0
-    eslint-plugin-prettier: 3.3.1
-    ethereum-waffle: ^3.4.0
-    ethers: ^5.5.4
-    hardhat: ^2.17.2
-    hardhat-deploy: ^0.10.4
-    hardhat-deploy-ethers: ^0.3.0-beta.13
-    hardhat-gas-reporter: ^1.0.7
-    hardhat-watcher: ^2.3.0
-    jest: 29.5.0
-    lodash.isequal: ^4.5.0
-    lodash.shuffle: ^4.2.0
-    prettier: ^2.6.2
-    prettier-plugin-solidity: ^1.0.0-beta.19
-    solhint: ^3.3.7
-    solidity-coverage: ^0.8.4
-    ts-jest: 29.1.0
-    ts-node: ^10.4.0
-    typechain: ^8.0.0
-    typescript: ^4.6.3
-    wait-on: ^6.0.1
-  languageName: unknown
-  linkType: soft
 
 "@statechannels/nitro-rpc-client@workspace:*, @statechannels/nitro-rpc-client@workspace:packages/nitro-rpc-client":
   version: 0.0.0-use.local


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Add `eth_getBlockByNumber` to paid RPC methods
- Fix payment proxy cmd build in Dockerfile
- Add option to pass hostname in `nitro-rpc-client` cli