### PR TITLE
Setup a payments manager with voucher cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,11 @@ require (
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/golang-jwt/jwt/v5 v5.0.0
+	github.com/hashicorp/golang-lru/v2 v2.0.5
 	github.com/libp2p/go-libp2p-kad-dht v0.24.2
 	github.com/tidwall/buntdb v1.2.10
 	github.com/urfave/cli/v2 v2.25.3
+	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 
 )
 
@@ -143,7 +145,6 @@ require (
 	go.uber.org/fx v1.20.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect
-	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
+github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -18,6 +18,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+// TODO: Remove in further rebasing
 // type ChainOpts struct {
 // 	ChainUrl        string
 // 	ChainStartBlock uint64

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -18,17 +18,6 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// TODO: Remove in further rebasing
-// type ChainOpts struct {
-// 	ChainUrl        string
-// 	ChainStartBlock uint64
-// 	ChainAuthToken  string
-// 	ChainPk         string
-// 	NaAddress       common.Address
-// 	VpaAddress      common.Address
-// 	CaAddress       common.Address
-// }
-
 func StartAnvil() (*exec.Cmd, error) {
 	chainCmd := exec.Command("anvil", "--chain-id", "1337", "--block-time", "1", "--silent")
 	chainCmd.Stdout = os.Stdout

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -18,15 +18,15 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-type ChainOpts struct {
-	ChainUrl        string
-	ChainStartBlock uint64
-	ChainAuthToken  string
-	ChainPk         string
-	NaAddress       common.Address
-	VpaAddress      common.Address
-	CaAddress       common.Address
-}
+// type ChainOpts struct {
+// 	ChainUrl        string
+// 	ChainStartBlock uint64
+// 	ChainAuthToken  string
+// 	ChainPk         string
+// 	NaAddress       common.Address
+// 	VpaAddress      common.Address
+// 	CaAddress       common.Address
+// }
 
 func StartAnvil() (*exec.Cmd, error) {
 	chainCmd := exec.Command("anvil", "--chain-id", "1337", "--block-time", "1", "--silent")

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/statechannels/go-nitro/internal/chain"
 	"github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/engine"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
@@ -15,7 +14,7 @@ import (
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 )
 
-func InitializeNode(pkString string, chainOpts chain.ChainOpts,
+func InitializeNode(pkString string, chainOpts chainservice.ChainOpts,
 	useDurableStore bool, durableStoreFolder string, msgPort int, wsMsgPort int, bootPeers []string,
 ) (*node.Node, *store.Store, *p2pms.P2PMessageService, chainservice.ChainService, error) {
 	if pkString == "" {

--- a/main.go
+++ b/main.go
@@ -9,10 +9,10 @@ import (
 	"syscall"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/statechannels/go-nitro/internal/chain"
 	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/node"
 	"github.com/statechannels/go-nitro/internal/rpc"
+	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )
@@ -180,7 +180,7 @@ func main() {
 		Flags:  flags,
 		Before: altsrc.InitInputSourceWithContext(flags, altsrc.NewTomlSourceFromFlagFunc(CONFIG)),
 		Action: func(cCtx *cli.Context) error {
-			chainOpts := chain.ChainOpts{
+			chainOpts := chainservice.ChainOpts{
 				ChainUrl:        chainUrl,
 				ChainStartBlock: chainStartBlock,
 				ChainAuthToken:  chainAuthToken,

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -14,7 +14,6 @@ import (
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/statechannels/go-nitro/channel/state"
-	"github.com/statechannels/go-nitro/internal/chain"
 	"github.com/statechannels/go-nitro/internal/logging"
 	NitroAdjudicator "github.com/statechannels/go-nitro/node/engine/chainservice/adjudicator"
 	Token "github.com/statechannels/go-nitro/node/engine/chainservice/erc20"
@@ -38,6 +37,16 @@ var topicsToWatch = []common.Hash{
 	depositedTopic,
 	challengeRegisteredTopic,
 	challengeClearedTopic,
+}
+
+type ChainOpts struct {
+	ChainUrl        string
+	ChainStartBlock uint64
+	ChainAuthToken  string
+	ChainPk         string
+	NaAddress       common.Address
+	VpaAddress      common.Address
+	CaAddress       common.Address
 }
 
 type ethChain interface {
@@ -80,7 +89,7 @@ const RESUB_INTERVAL = 15 * time.Second
 const REQUIRED_BLOCK_CONFIRMATIONS = 2
 
 // NewEthChainService is a convenient wrapper around newEthChainService, which provides a simpler API
-func NewEthChainService(chainOpts chain.ChainOpts) (ChainService, error) {
+func NewEthChainService(chainOpts ChainOpts) (ChainService, error) {
 	if chainOpts.ChainPk == "" {
 		return nil, fmt.Errorf("chainpk must be set")
 	}

--- a/paymentsmanager/http_middleware.go
+++ b/paymentsmanager/http_middleware.go
@@ -58,7 +58,9 @@ func extractAndValidateVoucher(r *http.Request, validator VoucherValidator, quer
 	}
 
 	// Determine signer from the voucher hash and signature
-	signer, err := crypto.RecoverEthereumMessageSigner(common.Hex2Bytes(vhash), crypto.SplitSignature(common.Hex2Bytes(vsig)))
+	vhashBytes := common.Hex2Bytes(strings.TrimPrefix(vhash, "0x"))
+	signature := crypto.SplitSignature(common.Hex2Bytes(strings.TrimPrefix(vsig, "0x")))
+	signer, err := crypto.RecoverEthereumMessageSigner(vhashBytes, signature)
 	if err != nil {
 		return r, ERR_UNABLE_TO_RECOVER_SIGNER
 	}

--- a/paymentsmanager/http_middleware.go
+++ b/paymentsmanager/http_middleware.go
@@ -1,0 +1,34 @@
+package paymentsmanager
+
+import (
+	"math/big"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func extractAndValidateVoucher(r *http.Request, validator VoucherValidator) (*http.Request, error) {
+	// TODO: Determine RPC method from the request
+	// TODO: Extract voucher details from the header
+
+	voucherHash := common.HexToHash("")
+	signer := common.HexToAddress("")
+	amount := big.NewInt(0)
+
+	return r, validator.ValidateVoucher(voucherHash, signer, amount)
+}
+
+// HTTPMiddleware http connection metric reader
+func HTTPMiddleware(next http.Handler, validator VoucherValidator) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Authenticate payments
+		r, err := extractAndValidateVoucher(r, validator)
+		if err != nil {
+			// TODO: Throw payment related error
+			// w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/paymentsmanager/http_middleware.go
+++ b/paymentsmanager/http_middleware.go
@@ -1,34 +1,124 @@
 package paymentsmanager
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
 	"math/big"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/crypto"
+	"golang.org/x/exp/slog"
 )
 
-func extractAndValidateVoucher(r *http.Request, validator VoucherValidator) (*http.Request, error) {
-	// TODO: Determine RPC method from the request
-	// TODO: Extract voucher details from the header
+const (
+	PAYMENT_HEADER_KEY   = "x-payment"
+	PAYMENT_HEADER_REGEX = "vhash:(.*),vsig:(.*)"
+)
 
-	voucherHash := common.HexToHash("")
-	signer := common.HexToAddress("")
-	amount := big.NewInt(0)
+var (
+	ERR_HEADER_MISSING           = errors.New("Payment header x-payment not set")
+	ERR_INVALID_PAYMENT_HEADER   = errors.New("Invalid payment header format")
+	ERR_UNABLE_TO_RECOVER_SIGNER = errors.New("Unable to recover the voucher signer")
+)
 
-	return r, validator.ValidateVoucher(voucherHash, signer, amount)
+func extractAndValidateVoucher(r *http.Request, validator VoucherValidator, queryRates map[string]*big.Int) (*http.Request, error) {
+	// Determine RPC method from the request
+	isRpcCall, rpcMethod := isRpcCall(r)
+	if !isRpcCall {
+		return r, nil
+	}
+
+	// Determine the query cost
+	queryCost := queryRates[rpcMethod]
+	if queryCost == nil || queryCost.Cmp(big.NewInt(0)) == 0 {
+		slog.Info("Serving a free RPC request", "method", rpcMethod)
+		return r, nil
+	}
+
+	// Extract voucher details from the header
+	paymentHeader := r.Header.Get(PAYMENT_HEADER_KEY)
+	if paymentHeader == "" {
+		return r, ERR_HEADER_MISSING
+	}
+
+	re := regexp.MustCompile(PAYMENT_HEADER_REGEX)
+	match := re.FindStringSubmatch(paymentHeader)
+
+	var vhash, vsig string
+	if match != nil {
+		vhash = match[1]
+		vsig = match[2]
+	} else {
+		return r, ERR_INVALID_PAYMENT_HEADER
+	}
+
+	// Determine signer from the voucher hash and signature
+	signer, err := crypto.RecoverEthereumMessageSigner(common.Hex2Bytes(vhash), crypto.SplitSignature(common.Hex2Bytes(vsig)))
+	if err != nil {
+		return r, ERR_UNABLE_TO_RECOVER_SIGNER
+	}
+
+	// Remove the payment header from the request
+	r.Header.Del(PAYMENT_HEADER_KEY)
+
+	err = validator.ValidateVoucher(common.HexToHash(vhash), signer, queryCost)
+	if err != nil {
+		return r, err
+	}
+
+	slog.Info("Serving a paid RPC request", "method", rpcMethod, "sender", signer)
+	return r, nil
 }
 
 // HTTPMiddleware http connection metric reader
-func HTTPMiddleware(next http.Handler, validator VoucherValidator) http.Handler {
+func HTTPMiddleware(next http.Handler, validator VoucherValidator, queryRates map[string]*big.Int) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Authenticate payments
-		r, err := extractAndValidateVoucher(r, validator)
+		// Validate voucher
+		r, err := extractAndValidateVoucher(r, validator, queryRates)
 		if err != nil {
-			// TODO: Throw payment related error
-			// w.WriteHeader(http.StatusBadRequest)
+			if strings.Contains(err.Error(), ERR_PAYMENT) {
+				http.Error(w, err.Error(), http.StatusPaymentRequired)
+			} else {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			}
+
 			return
 		}
 
+		// Let the request move ahead after voucher validation
 		next.ServeHTTP(w, r)
 	})
+}
+
+// Helper method to parse request and determine whether it's a RPC call
+// A request is a RPC call if:
+//   - "Content-Type" header is set to "application/json"
+//   - Request body has non-empty "jsonrpc" and "method" fields
+//
+// Also returns the parsed RPC method
+func isRpcCall(r *http.Request) (bool, string) {
+	if r.Header.Get("Content-Type") != "application/json" {
+		return false, ""
+	}
+
+	var ReqBody struct {
+		JsonRpc string `json:"jsonrpc"`
+		Method  string `json:"method"`
+	}
+	bodyBytes, _ := io.ReadAll(r.Body)
+
+	err := json.Unmarshal(bodyBytes, &ReqBody)
+	if err != nil || ReqBody.JsonRpc == "" || ReqBody.Method == "" {
+		return false, ""
+	}
+
+	// Reassign request body as io.ReadAll consumes it
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	return true, ReqBody.Method
 }

--- a/paymentsmanager/http_middleware.go
+++ b/paymentsmanager/http_middleware.go
@@ -73,7 +73,7 @@ func extractAndValidateVoucher(r *http.Request, validator VoucherValidator, quer
 		return r, err
 	}
 
-	slog.Info("Serving a paid RPC request", "method", rpcMethod, "sender", signer)
+	slog.Info("Serving a paid RPC request", "method", rpcMethod, "sender", signer.Hex())
 	return r, nil
 }
 

--- a/paymentsmanager/payments_manager.go
+++ b/paymentsmanager/payments_manager.go
@@ -56,6 +56,8 @@ func NewPaymentsManager(nitro *node.Node) (PaymentsManager, error) {
 		time.Second*DEFAULT_LRU_CACHE_PAYMENT_CHANNEL_TTL,
 	)
 
+	pm.quitChan = make(chan bool)
+
 	// Load existing open payment channels with amount paid so far from the stored state
 	err := pm.loadPaymentChannels()
 	if err != nil {

--- a/paymentsmanager/payments_manager.go
+++ b/paymentsmanager/payments_manager.go
@@ -31,7 +31,7 @@ type InFlightVoucher struct {
 }
 
 type PaymentsManager struct {
-	nitro node.Node
+	nitro *node.Node
 
 	receivedVouchersCache *expirable.LRU[common.Address, *expirable.LRU[common.Hash, InFlightVoucher]]
 
@@ -41,7 +41,7 @@ type PaymentsManager struct {
 	quitChan chan bool
 }
 
-func NewPaymentsManager(nitro node.Node) (PaymentsManager, error) {
+func NewPaymentsManager(nitro *node.Node) (PaymentsManager, error) {
 	pm := PaymentsManager{nitro: nitro}
 
 	pm.receivedVouchersCache = expirable.NewLRU[common.Address, *expirable.LRU[common.Hash, InFlightVoucher]](

--- a/paymentsmanager/validator.go
+++ b/paymentsmanager/validator.go
@@ -5,13 +5,12 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/statechannels/go-nitro/rpc"
 )
 
 var (
-	ERR_PAYMENT              = "Payment error:"
-	ERR_PAYMENT_NOT_RECEIVED = fmt.Errorf("%s payment not received", ERR_PAYMENT)
-	ERR_AMOUNT_INSUFFICIENT  = fmt.Errorf("%s amount insufficient", ERR_PAYMENT)
+	ErrPayment            = "Payment error:"
+	ErrPaymentNotReceived = fmt.Errorf("%s payment not received", ErrPayment)
+	ErrAmountInsufficient = fmt.Errorf("%s amount insufficient", ErrPayment)
 )
 
 // Voucher validator interface to be satisfied by implementations
@@ -31,11 +30,11 @@ func (v InProcessVoucherValidator) ValidateVoucher(voucherHash common.Hash, sign
 	isPaymentReceived, isOfSufficientValue := v.PaymentsManager.ValidateVoucher(voucherHash, signerAddress, value)
 
 	if !isPaymentReceived {
-		return ERR_PAYMENT_NOT_RECEIVED
+		return ErrPaymentNotReceived
 	}
 
 	if !isOfSufficientValue {
-		return ERR_AMOUNT_INSUFFICIENT
+		return ErrAmountInsufficient
 	}
 
 	return nil
@@ -45,7 +44,7 @@ var _ VoucherValidator = &RemoteVoucherValidator{}
 
 // When go-nitro is running remotely
 type RemoteVoucherValidator struct {
-	client rpc.RpcClientApi //nolint:unused
+	// client rpc.RpcClientApi
 }
 
 func (r RemoteVoucherValidator) ValidateVoucher(voucherHash common.Hash, signerAddress common.Address, value *big.Int) error {

--- a/paymentsmanager/validator.go
+++ b/paymentsmanager/validator.go
@@ -1,0 +1,47 @@
+package paymentsmanager
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/rpc"
+)
+
+var (
+	ERR_PAYMENT_NOT_RECEIVED = errors.New("Payment not received")
+	ERR_AMOUNT_INSUFFICIENT  = errors.New("Payment amount insufficient")
+)
+
+type VoucherValidator interface {
+	ValidateVoucher(voucherHash common.Hash, signerAddress common.Address, value *big.Int) error
+}
+
+// When go-nitro is running in-process
+type InProcessValidator struct {
+	PaymentsManager
+}
+
+func (v InProcessValidator) ValidateVoucher(voucherHash common.Hash, signerAddress common.Address, value *big.Int) error {
+	isPaymentReceived, isOfSufficientValue := v.PaymentsManager.ValidateVoucher(voucherHash, signerAddress, value)
+
+	if !isPaymentReceived {
+		return ERR_PAYMENT_NOT_RECEIVED
+	}
+
+	if !isOfSufficientValue {
+		return ERR_AMOUNT_INSUFFICIENT
+	}
+
+	return nil
+}
+
+// When go-nitro is running remotely
+type RemoteValidator struct {
+	client rpc.RpcClientApi
+}
+
+func (r RemoteValidator) ValidateVoucher(voucherHash common.Hash, signerAddress common.Address, value *big.Int) error {
+	// TODO: Implement
+	return nil
+}

--- a/paymentsmanager/validator.go
+++ b/paymentsmanager/validator.go
@@ -2,6 +2,7 @@ package paymentsmanager
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -9,8 +10,9 @@ import (
 )
 
 var (
-	ERR_PAYMENT_NOT_RECEIVED = errors.New("Payment not received")
-	ERR_AMOUNT_INSUFFICIENT  = errors.New("Payment amount insufficient")
+	ERR_PAYMENT              = "Payment error:"
+	ERR_PAYMENT_NOT_RECEIVED = errors.New(fmt.Sprintf("%s payment not received", ERR_PAYMENT))
+	ERR_AMOUNT_INSUFFICIENT  = errors.New(fmt.Sprintf("%s amount insufficient", ERR_PAYMENT))
 )
 
 type VoucherValidator interface {


### PR DESCRIPTION
Part of [Support running go-nitro node in/out of process in ipld-eth-server](https://www.notion.so/Support-running-go-nitro-node-in-out-of-process-in-ipld-eth-server-f592e29f0e5b474aa65db1509e5ddf1b)

To be handled in upcoming PRs:
- Pre-loading of "paid so far" amounts on open payment channels
- Voucher validator implementation with remotely running `go-nitro` node  