### PR TITLE
Load payment channels on startup and change return type for validation API 

### DIFF
--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -183,6 +183,9 @@ func setupRPCServer(n name, c color, na, vpa, ca types.Address, chainUrl, chainA
 
 	args = append(args, "-durablestorefolder", dataFolder)
 
+	args = append(args, "-tlscertfilepath", "./tls/statechannels.org.pem")
+	args = append(args, "-tlskeyfilepath", "./tls/statechannels.org_key.pem")
+
 	args = append(args, "-config", fmt.Sprintf("./cmd/test-configs/%s.toml", n))
 
 	cmd := exec.Command("go", args...)

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -29,7 +29,8 @@ async function initializeClients(): Promise<Clients> {
   const clients: Clients = new Map<ClientNames, NitroRpcClient>();
   for (const clientName of clientNames) {
     const client = await NitroRpcClient.CreateHttpNitroClient(
-      getLocalRPCUrl(port)
+      getLocalRPCUrl(port),
+      true
     );
     clients.set(clientName, client);
     port++;

--- a/paymentsmanager/payments_manager.go
+++ b/paymentsmanager/payments_manager.go
@@ -1,7 +1,6 @@
 package paymentsmanager
 
 import (
-	"fmt"
 	"log/slog"
 	"math/big"
 	"sync"
@@ -28,9 +27,8 @@ const (
 )
 
 var (
-	ERR_PAYMENT              = "Payment error:"
-	ERR_PAYMENT_NOT_RECEIVED = fmt.Sprintf("%s payment not received", ERR_PAYMENT)
-	ERR_AMOUNT_INSUFFICIENT  = fmt.Sprintf("%s amount insufficient", ERR_PAYMENT)
+	ERR_PAYMENT_NOT_RECEIVED        = "ERR_PAYMENT_NOT_RECEIVED"
+	ERR_PAYMENT_AMOUNT_INSUFFICIENT = "ERR_PAYMENT_AMOUNT_INSUFFICIENT"
 )
 
 type InFlightVoucher struct {
@@ -104,7 +102,7 @@ func (pm *PaymentsManager) ValidateVoucher(voucherHash common.Hash, signerAddres
 
 		if isPaymentReceived {
 			if !isOfSufficientValue {
-				return false, ERR_AMOUNT_INSUFFICIENT
+				return false, ERR_PAYMENT_AMOUNT_INSUFFICIENT
 			}
 			return true, ""
 		}

--- a/paymentsmanager/validator.go
+++ b/paymentsmanager/validator.go
@@ -27,14 +27,10 @@ type InProcessVoucherValidator struct {
 }
 
 func (v InProcessVoucherValidator) ValidateVoucher(voucherHash common.Hash, signerAddress common.Address, value *big.Int) error {
-	isPaymentReceived, isOfSufficientValue := v.PaymentsManager.ValidateVoucher(voucherHash, signerAddress, value)
+	isValid, reason := v.PaymentsManager.ValidateVoucher(voucherHash, signerAddress, value)
 
-	if !isPaymentReceived {
-		return ErrPaymentNotReceived
-	}
-
-	if !isOfSufficientValue {
-		return ErrAmountInsufficient
+	if !isValid {
+		return fmt.Errorf(reason)
 	}
 
 	return nil

--- a/paymentsmanager/validator.go
+++ b/paymentsmanager/validator.go
@@ -27,10 +27,10 @@ type InProcessVoucherValidator struct {
 }
 
 func (v InProcessVoucherValidator) ValidateVoucher(voucherHash common.Hash, signerAddress common.Address, value *big.Int) error {
-	isValid, reason := v.PaymentsManager.ValidateVoucher(voucherHash, signerAddress, value)
+	success, errCode := v.PaymentsManager.ValidateVoucher(voucherHash, signerAddress, value)
 
-	if !isValid {
-		return fmt.Errorf(reason)
+	if !success {
+		return fmt.Errorf(errCode)
 	}
 
 	return nil

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -113,8 +113,8 @@ type (
 )
 
 type ValidateVoucherResponse struct {
-	IsValid bool
-	Reason  string
+	Success   bool
+	ErrorCode string
 }
 
 type ResponsePayload interface {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -113,8 +113,8 @@ type (
 )
 
 type ValidateVoucherResponse struct {
-	IsPaymentReceived   bool
-	IsOfSufficientValue bool
+	IsValid bool
+	Reason  string
 }
 
 type ResponsePayload interface {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -190,8 +190,8 @@ func (rs *RpcServer) registerHandlers() (err error) {
 			})
 		case serde.ValidateVoucherRequestMethod:
 			return processRequest(rs, permRead, requestData, func(req serde.ValidateVoucherRequest) (serde.ValidateVoucherResponse, error) {
-				isValid, reason := rs.paymentManager.ValidateVoucher(req.VoucherHash, req.Signer, big.NewInt(int64(req.Value)))
-				response := serde.ValidateVoucherResponse{IsValid: isValid, Reason: reason}
+				success, errCode := rs.paymentManager.ValidateVoucher(req.VoucherHash, req.Signer, big.NewInt(int64(req.Value)))
+				response := serde.ValidateVoucherResponse{Success: success, ErrorCode: errCode}
 				return response, nil
 			})
 		default:

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -190,8 +190,8 @@ func (rs *RpcServer) registerHandlers() (err error) {
 			})
 		case serde.ValidateVoucherRequestMethod:
 			return processRequest(rs, permRead, requestData, func(req serde.ValidateVoucherRequest) (serde.ValidateVoucherResponse, error) {
-				isPaymentReceived, isOfSufficientValue := rs.paymentManager.ValidateVoucher(req.VoucherHash, req.Signer, big.NewInt(int64(req.Value)))
-				response := serde.ValidateVoucherResponse{IsPaymentReceived: isPaymentReceived, IsOfSufficientValue: isOfSufficientValue}
+				isValid, reason := rs.paymentManager.ValidateVoucher(req.VoucherHash, req.Signer, big.NewInt(int64(req.Value)))
+				response := serde.ValidateVoucherResponse{IsValid: isValid, Reason: reason}
 				return response, nil
 			})
 		default:

--- a/rpc/voucher_validator.go
+++ b/rpc/voucher_validator.go
@@ -21,8 +21,8 @@ func (r RemoteVoucherValidator) ValidateVoucher(voucherHash common.Hash, signerA
 		return err
 	}
 
-	if !res.IsValid {
-		return fmt.Errorf(res.Reason)
+	if !res.Success {
+		return fmt.Errorf(res.ErrorCode)
 	}
 
 	return nil

--- a/rpc/voucher_validator.go
+++ b/rpc/voucher_validator.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -20,12 +21,8 @@ func (r RemoteVoucherValidator) ValidateVoucher(voucherHash common.Hash, signerA
 		return err
 	}
 
-	if !res.IsPaymentReceived {
-		return paymentsmanager.ErrPaymentNotReceived
-	}
-
-	if !res.IsOfSufficientValue {
-		return paymentsmanager.ErrAmountInsufficient
+	if !res.IsValid {
+		return fmt.Errorf(res.Reason)
 	}
 
 	return nil


### PR DESCRIPTION
Part of [Implement remaining ipld-eth-server config and load payment channels on startup](https://www.notion.so/Implement-remaining-ipld-eth-server-config-and-load-payment-channels-on-startup-5fcb33e49d504d618169a2089740eb67)