### PR TITLE
Counter challenge CLI to counter or clear challenge

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -379,7 +379,9 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 		c.OnChain.Outcome = outcome.Exit{}
 		c.OnChain.FinalizesAt = common.Big0
 
-	// TODO: Handle checkpoint event
+	// TODO: Handle Checkpointed event
+	// Checkpointed event is emitted after a checkpoint transaction occurs on an open channel
+	// checkpoint method of ForceMove.sol contract
 	default:
 		return &Channel{}, fmt.Errorf("channel %+v cannot handle event %+v", c, event)
 	}

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -374,7 +374,12 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 		}
 		c.AddSignedState(ss)
 
-	// TODO: Handle challenge cleared event
+	case chainservice.ChallengeClearedEvent:
+		c.OnChain.StateHash = common.Hash{}
+		c.OnChain.Outcome = outcome.Exit{}
+		c.OnChain.FinalizesAt = common.Big0
+
+	// TODO: Handle checkpoint event
 	default:
 		return &Channel{}, fmt.Errorf("channel %+v cannot handle event %+v", c, event)
 	}

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -375,6 +375,7 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 		c.AddSignedState(ss)
 
 	case chainservice.ChallengeClearedEvent:
+		// On chain, statusOf map is updated with the same values below following a checkpoint transaction in ForceMove contract
 		c.OnChain.StateHash = common.Hash{}
 		c.OnChain.Outcome = outcome.Exit{}
 		c.OnChain.FinalizesAt = common.Big0

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -608,7 +608,7 @@ func (e *Engine) handleCounterChallengeRequest(request types.CounterChallengeReq
 	switch request.Action {
 	case types.Checkpoint:
 		obj.IsCheckpoint = true
-	case types.CounterChallenge:
+	case types.Challenge:
 		obj.IsChallengeInitiatedByMe = true
 	default:
 		return fmt.Errorf("Unknown counter challenge action")

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -702,7 +702,7 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Engine
 			return
 		}
 
-		err = e.destoryObjectiveAndChannelIfDirectDeFundObjectiveInChallenge(crankedObjective)
+		err = e.destoryObjectiveAndChannelIfDirectDeFundObjectivesChallengeIsCleared(crankedObjective)
 		if err != nil {
 			return
 		}
@@ -787,11 +787,13 @@ func (e Engine) spawnConsensusChannelIfDirectFundObjective(crankedObjective prot
 	return nil
 }
 
-func (e Engine) destoryObjectiveAndChannelIfDirectDeFundObjectiveInChallenge(crankedObjective protocols.Objective) error {
+// destoryObjectiveAndChannelIfDirectDeFundObjectivesChallengeIsCleared attempts to create and store a ConsensusChannel
+// derived from the supplied Objective if it is a directdefund.Objective and its challenge has been cleared.
+// If successful, the associated objective and channel will be destroyed.
+func (e Engine) destoryObjectiveAndChannelIfDirectDeFundObjectivesChallengeIsCleared(crankedObjective protocols.Objective) error {
 	dDfo, isDdfo := crankedObjective.(*directdefund.Objective)
 
-	// TODO: Test the conditions
-	if isDdfo && (dDfo.IsChallengeInitiatedByMe || dDfo.IsCheckpoint) {
+	if isDdfo && !dDfo.FullyWithdrawn() {
 		c, err := dDfo.CreateConsensusChannel()
 		if err != nil {
 			return fmt.Errorf("could not create consensus channel for objective %s: %w", crankedObjective.Id(), err)

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -603,7 +603,7 @@ func (e *Engine) handleCounterChallengeRequest(request types.CounterChallengeReq
 	obj, ok := objective.(*directdefund.Objective)
 
 	if !ok {
-		return fmt.Errorf("Direct defund objective required")
+		return fmt.Errorf("direct defund objective required")
 	}
 
 	switch request.Action {
@@ -612,7 +612,7 @@ func (e *Engine) handleCounterChallengeRequest(request types.CounterChallengeReq
 	case types.Challenge:
 		obj.IsChallengeInitiatedByMe = true
 	default:
-		return fmt.Errorf("Unknown counter challenge action")
+		return fmt.Errorf("unknown counter challenge action")
 	}
 
 	_, err = e.attemptProgress(objective)

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -596,6 +596,7 @@ func (e *Engine) handlePaymentRequest(request PaymentRequest) (EngineEvent, erro
 
 func (e *Engine) handleCounterChallengeRequest(request types.CounterChallengeRequest) error {
 	objective, _ := e.store.GetObjectiveById(protocols.ObjectiveId(directdefund.ObjectivePrefix + request.ChannelId.String()))
+	// TODO: Check objective type to be direct defund
 	_, err := e.attemptProgress(objective)
 	if err != nil {
 		return err

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -594,6 +594,7 @@ func (e *Engine) handlePaymentRequest(request PaymentRequest) (EngineEvent, erro
 	return ee, e.executeSideEffects(se)
 }
 
+// handleCounterChallengeRequest handles a counter challenge request for the given channel.
 func (e *Engine) handleCounterChallengeRequest(request types.CounterChallengeRequest) error {
 	objective, err := e.store.GetObjectiveById(protocols.ObjectiveId(directdefund.ObjectivePrefix + request.ChannelId.String()))
 	if err != nil {
@@ -702,7 +703,7 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Engine
 			return
 		}
 
-		err = e.destoryObjectiveAndChannelIfDirectDeFundObjectivesChallengeIsCleared(crankedObjective)
+		err = e.destroyObjectiveAndChannelIfChallengeCleared(crankedObjective)
 		if err != nil {
 			return
 		}
@@ -787,14 +788,14 @@ func (e Engine) spawnConsensusChannelIfDirectFundObjective(crankedObjective prot
 	return nil
 }
 
-// destoryObjectiveAndChannelIfDirectDeFundObjectivesChallengeIsCleared attempts to create and store a ConsensusChannel
+// destroyObjectiveAndChannelIfChallengeCleared attempts to create and store a ConsensusChannel
 // derived from the supplied Objective if it is a directdefund.Objective and its challenge has been cleared.
 // If successful, the associated objective and channel will be destroyed.
-func (e Engine) destoryObjectiveAndChannelIfDirectDeFundObjectivesChallengeIsCleared(crankedObjective protocols.Objective) error {
+func (e Engine) destroyObjectiveAndChannelIfChallengeCleared(crankedObjective protocols.Objective) error {
 	dDfo, isDdfo := crankedObjective.(*directdefund.Objective)
 
 	if isDdfo && !dDfo.FullyWithdrawn() {
-		c, err := dDfo.CreateConsensusChannel()
+		c, err := dDfo.CreateConsensusChannelFromChannel()
 		if err != nil {
 			return fmt.Errorf("could not create consensus channel for objective %s: %w", crankedObjective.Id(), err)
 		}

--- a/node/engine/store/durablestore.go
+++ b/node/engine/store/durablestore.go
@@ -670,3 +670,8 @@ func (ds *DurableStore) RemoveVoucherInfo(channelId types.Destination) error {
 		return err
 	})
 }
+
+func (ds *DurableStore) DestroyObjective(id protocols.ObjectiveId) error {
+	// TODO: Destroy the objective
+	return nil
+}

--- a/node/engine/store/durablestore.go
+++ b/node/engine/store/durablestore.go
@@ -672,6 +672,8 @@ func (ds *DurableStore) RemoveVoucherInfo(channelId types.Destination) error {
 }
 
 func (ds *DurableStore) DestroyObjective(id protocols.ObjectiveId) error {
-	// TODO: Destroy the objective
-	return nil
+	return ds.objectives.Update(func(tx *buntdb.Tx) error {
+		_, err := tx.Delete(string(id))
+		return err
+	})
 }

--- a/node/engine/store/memstore.go
+++ b/node/engine/store/memstore.go
@@ -166,6 +166,11 @@ func (ms *MemStore) DestroyChannel(id types.Destination) error {
 	return nil
 }
 
+func (ms *MemStore) DestroyObjective(id protocols.ObjectiveId) error {
+	ms.objectives.Delete(string(id))
+	return nil
+}
+
 // SetConsensusChannel sets the channel in the store.
 func (ms *MemStore) SetConsensusChannel(ch *consensus_channel.ConsensusChannel) error {
 	if ch.Id.IsZero() {

--- a/node/engine/store/store.go
+++ b/node/engine/store/store.go
@@ -29,8 +29,8 @@ type Store interface {
 	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
-	DestroyObjective(id protocols.ObjectiveId) error
-	GetChannelsByIds(ids []types.Destination) ([]*channel.Channel, error) // Returns a collection of channels with the given ids
+	DestroyObjective(id protocols.ObjectiveId) error                              // Deletes an objective identified by the given ObjectiveId
+	GetChannelsByIds(ids []types.Destination) ([]*channel.Channel, error)         // Returns a collection of channels with the given ids
 	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
 	GetChannelsByParticipant(participant types.Address) ([]*channel.Channel, error) // Returns any channels that includes the given participant
 	GetAllChannels() ([]*channel.Channel, error)

--- a/node/engine/store/store.go
+++ b/node/engine/store/store.go
@@ -29,7 +29,8 @@ type Store interface {
 	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
-	GetChannelsByIds(ids []types.Destination) ([]*channel.Channel, error)         // Returns a collection of channels with the given ids
+	DestroyObjective(id protocols.ObjectiveId) error
+	GetChannelsByIds(ids []types.Destination) ([]*channel.Channel, error) // Returns a collection of channels with the given ids
 	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
 	GetChannelsByParticipant(participant types.Address) ([]*channel.Channel, error) // Returns any channels that includes the given participant
 	GetAllChannels() ([]*channel.Channel, error)

--- a/node/node.go
+++ b/node/node.go
@@ -72,6 +72,7 @@ func (n *Node) handleEngineEvent(update engine.EngineEvent) {
 	for _, completed := range update.CompletedObjectives {
 		d, _ := n.completedObjectives.LoadOrStore(string(completed.Id()), make(chan struct{}))
 		close(d)
+		n.completedObjectives.Delete(string(completed.Id()))
 
 		// use a nonblocking send to the RPC Client in case no one is listening
 		select {

--- a/node/node.go
+++ b/node/node.go
@@ -323,3 +323,7 @@ func (n *Node) handleError(err error) {
 
 	}
 }
+
+func (n *Node) CounterChallenge(id types.Destination, action types.CounterChallengeAction) {
+	n.engine.CounterChallengeRequestsFromAPI <- types.CounterChallengeRequest{ChannelId: id, Action: action}
+}

--- a/node/query/query.go
+++ b/node/query/query.go
@@ -19,6 +19,10 @@ import (
 
 // getStatusFromChannel returns the status of the channel
 func getStatusFromChannel(c *channel.Channel) ChannelStatus {
+	if c.OnChain.FinalizesAt.Cmp(big.NewInt(0)) != 0 && !c.OnChain.Holdings.IsNonZero() {
+		return Complete
+	}
+
 	if c.FinalSignedByMe() {
 		if c.FinalCompleted() {
 			return Complete

--- a/node/query/query.go
+++ b/node/query/query.go
@@ -19,6 +19,7 @@ import (
 
 // getStatusFromChannel returns the status of the channel
 func getStatusFromChannel(c *channel.Channel) ChannelStatus {
+	// If the assets are liquidated for a challenged channel, it indicates completion
 	if c.OnChain.FinalizesAt.Cmp(big.NewInt(0)) != 0 && !c.OnChain.Holdings.IsNonZero() {
 		return Complete
 	}

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -72,8 +72,10 @@ func TestChallenge(t *testing.T) {
 	testhelpers.Assert(t, objB.C.GetChannelMode() == channel.Challenge, "Expected channel status to be challenge")
 
 	// Wait for objectives to complete
-	<-nodeA.ObjectiveCompleteChan(response)
-	<-nodeB.ObjectiveCompleteChan(response)
+	chA := nodeA.ObjectiveCompleteChan(response)
+	chB := nodeB.ObjectiveCompleteChan(response)
+	<-chA
+	<-chB
 
 	// Check assets are liquidated
 	balanceNodeA, _ = infra.anvilChain.GetAccountBalance(testCase.Participants[0].Address())

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -7,6 +7,7 @@ import { hideBin } from "yargs/helpers";
 
 import { NitroRpcClient } from "./rpc-client";
 import { compactJson, getLocalRPCUrl, logOutChannelUpdates } from "./utils";
+import { CounterChallengeAction } from "./types";
 
 yargs(hideBin(process.argv))
   .scriptName("nitro-rpc-client")
@@ -321,6 +322,40 @@ yargs(hideBin(process.argv))
         yargs.amount
       );
       console.log(paymentChannelInfo);
+      await rpcClient.Close();
+      process.exit(0);
+    }
+  )
+  .command(
+    "counter-challenge <channelId> <action>",
+    "Counter challenge the registered challenge",
+    (yargsBuilder) => {
+      return yargsBuilder
+        .positional("channelId", {
+          describe: "The channel ID of the payment channel",
+          type: "string",
+          demandOption: true,
+        })
+        .positional("action", {
+          describe: "The action to take",
+          type: "string",
+          choices: ["counterChallenge", "checkpoint", "liquidateAssets", "doNothing"],
+          demandOption: true,
+        });
+    },
+    async (yargs) => {
+      const rpcPort = yargs.p;
+
+      const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
+        getLocalRPCUrl(rpcPort)
+      );
+      if (yargs.n) logOutChannelUpdates(rpcClient);
+
+      const response = await rpcClient.CounterChallenge(
+        yargs.channelId,
+        yargs.action as CounterChallengeAction
+      );
+      console.log(response);
       await rpcClient.Close();
       process.exit(0);
     }

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -145,7 +145,7 @@ yargs(hideBin(process.argv))
           type: "string",
           demandOption: true,
         })
-        .option("is-challenge", {
+        .option("isChallenge", {
           describe: "To initiate challenge transaction",
           type: "boolean",
           default: false,
@@ -161,7 +161,7 @@ yargs(hideBin(process.argv))
 
       const id = await rpcClient.CloseLedgerChannel(
         yargs.channelId,
-        yargs["is-challenge"]
+        yargs.isChallenge
       );
       console.log(`Objective started ${id}`);
       await rpcClient.WaitForObjectiveToComplete(
@@ -352,6 +352,7 @@ yargs(hideBin(process.argv))
         getLocalRPCUrl(rpcPort)
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
+
       const response = await rpcClient.CounterChallenge(
         yargs.channelId,
         CounterChallengeAction[

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -164,6 +164,7 @@ yargs(hideBin(process.argv))
         yargs.isChallenge
       );
       console.log(`Objective started ${id}`);
+      // Not using WaitForLedgerChannelStatus method with complete status, as the ledger channel status will be open if a challenge is cleared using checkpoint
       await rpcClient.WaitForObjectiveToComplete(
         `DirectDefunding-${yargs.channelId}`
       );

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -352,7 +352,9 @@ yargs(hideBin(process.argv))
       if (yargs.n) logOutChannelUpdates(rpcClient);
       const response = await rpcClient.CounterChallenge(
         yargs.channelId,
-        CounterChallengeAction[yargs.action as keyof typeof CounterChallengeAction]
+        CounterChallengeAction[
+          yargs.action as keyof typeof CounterChallengeAction
+        ]
       );
       console.log(response);
       await rpcClient.Close();

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -136,7 +136,7 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
-    "direct-defund <channelId> <isChallenge>",
+    "direct-defund <channelId>",
     "Defunds a directly funded ledger channel",
     (yargsBuilder) => {
       return yargsBuilder
@@ -145,7 +145,7 @@ yargs(hideBin(process.argv))
           type: "string",
           demandOption: true,
         })
-        .option("isChallenge", {
+        .option("is-challenge", {
           describe: "To initiate challenge transaction",
           type: "boolean",
           default: false,
@@ -161,10 +161,10 @@ yargs(hideBin(process.argv))
 
       const id = await rpcClient.CloseLedgerChannel(
         yargs.channelId,
-        yargs.isChallenge
+        yargs["is-challenge"]
       );
       console.log(`Objective started ${id}`);
-      await rpcClient.WaitForPaymentChannelStatus(yargs.channelId, "Complete");
+      await rpcClient.WaitForLedgerChannelStatus(yargs.channelId, "Complete");
       console.log(`Channel Complete ${yargs.channelId}`);
       await rpcClient.Close();
       process.exit(0);
@@ -339,7 +339,7 @@ yargs(hideBin(process.argv))
         .positional("action", {
           describe: "The action to take",
           type: "string",
-          choices: ["Checkpoint", "CounterChallenge"],
+          choices: ["checkpoint", "challenge"],
           demandOption: true,
         });
     },

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -164,8 +164,10 @@ yargs(hideBin(process.argv))
         yargs["is-challenge"]
       );
       console.log(`Objective started ${id}`);
-      await rpcClient.WaitForLedgerChannelStatus(yargs.channelId, "Complete");
-      console.log(`Channel Complete ${yargs.channelId}`);
+      await rpcClient.WaitForObjectiveToComplete(
+        `DirectDefunding-${yargs.channelId}`
+      );
+      console.log(`Objective Complete ${yargs.channelId}`);
       await rpcClient.Close();
       process.exit(0);
     }
@@ -356,7 +358,13 @@ yargs(hideBin(process.argv))
           yargs.action as keyof typeof CounterChallengeAction
         ]
       );
-      console.log(response);
+      console.log(
+        `Sending ${response.Action} transaction for channel ${response.ChannelId}`
+      );
+      await rpcClient.WaitForObjectiveToComplete(
+        `DirectDefunding-${yargs.channelId}`
+      );
+      console.log(`Objective Complete ${response.ChannelId}`);
       await rpcClient.Close();
       process.exit(0);
     }

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -339,7 +339,7 @@ yargs(hideBin(process.argv))
         .positional("action", {
           describe: "The action to take",
           type: "string",
-          choices: ["counterChallenge", "checkpoint", "liquidateAssets", "doNothing"],
+          choices: ["Checkpoint", "CounterChallenge"],
           demandOption: true,
         });
     },
@@ -350,10 +350,9 @@ yargs(hideBin(process.argv))
         getLocalRPCUrl(rpcPort)
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
-
       const response = await rpcClient.CounterChallenge(
         yargs.channelId,
-        yargs.action as CounterChallengeAction
+        CounterChallengeAction[yargs.action as keyof typeof CounterChallengeAction]
       );
       console.log(response);
       await rpcClient.Close();

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -14,8 +14,8 @@ import {
   LedgerChannelUpdatedNotification,
   PaymentChannelUpdatedNotification,
   DirectDefundObjectiveRequest,
-  CounterChallengePayload,
   CounterChallengeAction,
+  CounterChallengeResult,
 } from "./types";
 import { Transport } from "./transport";
 import { createOutcome, generateRequest } from "./utils";
@@ -188,7 +188,7 @@ export class NitroRpcClient implements RpcClientApi {
   public async CounterChallenge(
     channelId: string,
     action: CounterChallengeAction
-  ): Promise<CounterChallengePayload> {
+  ): Promise<CounterChallengeResult> {
     const payload = {
       ChannelId: channelId,
       Action: action,

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -14,6 +14,8 @@ import {
   LedgerChannelUpdatedNotification,
   PaymentChannelUpdatedNotification,
   DirectDefundObjectiveRequest,
+  CounterChallengePayload,
+  CounterChallengeAction
 } from "./types";
 import { Transport } from "./transport";
 import { createOutcome, generateRequest } from "./utils";
@@ -181,6 +183,16 @@ export class NitroRpcClient implements RpcClientApi {
       IsChallenge: isChallenge,
     };
     return this.sendRequest("close_ledger_channel", payload);
+  }
+
+  public async CounterChallenge(channelId: string, action: CounterChallengeAction): Promise<CounterChallengePayload> {
+    const payload = {
+      Channel: channelId,
+      Action: action
+    };
+    const request = generateRequest("counter_challenge", payload, this.authToken || "");
+    const res = await this.transport.sendRequest<"counter_challenge">(request);
+    return getAndValidateResult(res, "counter_challenge");
   }
 
   public async ClosePaymentChannel(channelId: string): Promise<string> {

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -16,6 +16,7 @@ import {
   DirectDefundObjectiveRequest,
   CounterChallengeAction,
   CounterChallengeResult,
+  ObjectiveCompleteNotification,
 } from "./types";
 import { Transport } from "./transport";
 import { createOutcome, generateRequest } from "./utils";
@@ -60,6 +61,20 @@ export class NitroRpcClient implements RpcClientApi {
     );
     const res = await this.transport.sendRequest<"receive_voucher">(request);
     return getAndValidateResult(res, "receive_voucher");
+  }
+
+  public async WaitForObjectiveToComplete(objectiveId: string): Promise<void> {
+    const promise = new Promise<void>((resolve) => {
+      this.transport.Notifications.on(
+        "objective_completed",
+        (payload: ObjectiveCompleteNotification["params"]["payload"]) => {
+          if (payload === objectiveId) {
+            resolve();
+          }
+        }
+      );
+    });
+    return promise;
   }
 
   public async WaitForLedgerChannelStatus(

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -192,7 +192,8 @@ export class NitroRpcClient implements RpcClientApi {
     };
     const request = generateRequest("counter_challenge", payload, this.authToken || "");
     const res = await this.transport.sendRequest<"counter_challenge">(request);
-    return getAndValidateResult(res, "counter_challenge");
+    // TODO: Validate the response
+    return res as CounterChallengePayload
   }
 
   public async ClosePaymentChannel(channelId: string): Promise<string> {

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -190,17 +190,10 @@ export class NitroRpcClient implements RpcClientApi {
     action: CounterChallengeAction
   ): Promise<CounterChallengePayload> {
     const payload = {
-      Channel: channelId,
+      ChannelId: channelId,
       Action: action,
     };
-    const request = generateRequest(
-      "counter_challenge",
-      payload,
-      this.authToken || ""
-    );
-    const res = await this.transport.sendRequest<"counter_challenge">(request);
-    // TODO: Validate the response
-    return res as CounterChallengePayload;
+    return this.sendRequest("counter_challenge", payload);
   }
 
   public async ClosePaymentChannel(channelId: string): Promise<string> {

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -15,7 +15,7 @@ import {
   PaymentChannelUpdatedNotification,
   DirectDefundObjectiveRequest,
   CounterChallengePayload,
-  CounterChallengeAction
+  CounterChallengeAction,
 } from "./types";
 import { Transport } from "./transport";
 import { createOutcome, generateRequest } from "./utils";
@@ -185,15 +185,22 @@ export class NitroRpcClient implements RpcClientApi {
     return this.sendRequest("close_ledger_channel", payload);
   }
 
-  public async CounterChallenge(channelId: string, action: CounterChallengeAction): Promise<CounterChallengePayload> {
+  public async CounterChallenge(
+    channelId: string,
+    action: CounterChallengeAction
+  ): Promise<CounterChallengePayload> {
     const payload = {
       Channel: channelId,
-      Action: action
+      Action: action,
     };
-    const request = generateRequest("counter_challenge", payload, this.authToken || "");
+    const request = generateRequest(
+      "counter_challenge",
+      payload,
+      this.authToken || ""
+    );
     const res = await this.transport.sendRequest<"counter_challenge">(request);
     // TODO: Validate the response
-    return res as CounterChallengePayload
+    return res as CounterChallengePayload;
   }
 
   public async ClosePaymentChannel(channelId: string): Promise<string> {

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -2,6 +2,7 @@ import Ajv, { JTDDataType } from "ajv/dist/jtd";
 
 import {
   ChannelStatus,
+  CounterChallengePayload,
   LedgerChannelInfo,
   PaymentChannelInfo,
   RPCNotification,
@@ -167,7 +168,6 @@ export function getAndValidateResult<T extends RequestMethod>(
     case "close_ledger_channel":
     case "version":
     case "get_address":
-    case "counter_challenge":
     case "close_payment_channel":
       return validateAndConvertResult(
         stringSchema,
@@ -180,7 +180,9 @@ export function getAndValidateResult<T extends RequestMethod>(
         result,
         convertToInternalLedgerChannelType
       );
-
+    case "counter_challenge":
+      // TODO: Add validation for response
+      return {} as CounterChallengePayload
     case "get_all_ledger_channels":
       return validateAndConvertResult(
         ledgerChannelsSchema,

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -182,7 +182,7 @@ export function getAndValidateResult<T extends RequestMethod>(
       );
     case "counter_challenge":
       // TODO: Add validation for response
-      return {} as CounterChallengePayload
+      return {} as CounterChallengePayload;
     case "get_all_ledger_channels":
       return validateAndConvertResult(
         ledgerChannelsSchema,

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -2,6 +2,8 @@ import Ajv, { JTDDataType } from "ajv/dist/jtd";
 
 import {
   ChannelStatus,
+  CounterChallengeAction,
+  CounterChallengeResult,
   LedgerChannelInfo,
   PaymentChannelInfo,
   RPCNotification,
@@ -193,7 +195,7 @@ export function getAndValidateResult<T extends RequestMethod>(
       return validateAndConvertResult(
         counterChallengeSchema,
         result,
-        (result: CounterChallengeSchemaType) => result
+        convertToCounterChallengeResultType
       );
     case "get_all_ledger_channels":
       return validateAndConvertResult(
@@ -320,6 +322,17 @@ function convertToInternalLedgerChannelType(
       TheirBalance: BigInt(result.Balance.TheirBalance),
       MyBalance: BigInt(result.Balance.MyBalance),
     },
+  };
+}
+
+function convertToCounterChallengeResultType(
+  result: CounterChallengeSchemaType
+): CounterChallengeResult {
+  return {
+    ChannelId: result.ChannelId,
+    Action: CounterChallengeAction[
+      result.Action
+    ] as keyof typeof CounterChallengeAction,
   };
 }
 

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -2,7 +2,6 @@ import Ajv, { JTDDataType } from "ajv/dist/jtd";
 
 import {
   ChannelStatus,
-  CounterChallengePayload,
   LedgerChannelInfo,
   PaymentChannelInfo,
   RPCNotification,
@@ -43,6 +42,14 @@ type ObjectiveSchemaType = JTDDataType<typeof objectiveSchema>;
 
 const stringSchema = { type: "string" } as const;
 type StringSchemaType = JTDDataType<typeof stringSchema>;
+
+const counterChallengeSchema = {
+  properties: {
+    ChannelId: { type: "string" },
+    Action: { type: "int32" },
+  },
+} as const;
+type CounterChallengeSchemaType = JTDDataType<typeof counterChallengeSchema>;
 
 const ledgerChannelSchema = {
   properties: {
@@ -129,7 +136,8 @@ type ResponseSchema =
   | typeof paymentChannelsSchema
   | typeof paymentSchema
   | typeof voucherSchema
-  | typeof receiveVoucherSchema;
+  | typeof receiveVoucherSchema
+  | typeof counterChallengeSchema;
 
 type ResponseSchemaType =
   | ObjectiveSchemaType
@@ -140,7 +148,8 @@ type ResponseSchemaType =
   | PaymentChannelsSchemaType
   | PaymentSchemaType
   | VoucherSchemaType
-  | ReceiveVoucherSchemaType;
+  | ReceiveVoucherSchemaType
+  | CounterChallengeSchemaType;
 
 /**
  * Validates that the response is a valid JSON RPC response with a valid result
@@ -181,8 +190,11 @@ export function getAndValidateResult<T extends RequestMethod>(
         convertToInternalLedgerChannelType
       );
     case "counter_challenge":
-      // TODO: Add validation for response
-      return {} as CounterChallengePayload;
+      return validateAndConvertResult(
+        counterChallengeSchema,
+        result,
+        (result: CounterChallengeSchemaType) => result
+      );
     case "get_all_ledger_channels":
       return validateAndConvertResult(
         ledgerChannelsSchema,

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -167,6 +167,7 @@ export function getAndValidateResult<T extends RequestMethod>(
     case "close_ledger_channel":
     case "version":
     case "get_address":
+    case "counter_challenge":
     case "close_payment_channel":
       return validateAndConvertResult(
         stringSchema,

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -53,10 +53,8 @@ export type PaymentPayload = {
 };
 
 export enum CounterChallengeAction {
-  CounterChallenge = "counterChallenge",
-  Checkpoint = "checkpoint",
-  LiquidateAssets = "liquidateAssets",
-  DoNothing = "doNothing"
+  Checkpoint,
+  CounterChallenge,
 }
 
 export type CounterChallengePayload = {

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -58,7 +58,7 @@ export enum CounterChallengeAction {
 }
 
 export type CounterChallengePayload = {
-  Channel: string;
+  ChannelId: string;
   Action: CounterChallengeAction;
 };
 

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -62,6 +62,11 @@ export type CounterChallengePayload = {
   Action: CounterChallengeAction;
 };
 
+export type CounterChallengeResult = {
+  ChannelId: string;
+  Action: keyof typeof CounterChallengeAction;
+};
+
 export type Voucher = {
   ChannelId: string;
   // todo: this should be a bigint
@@ -108,7 +113,7 @@ export type DirectFundRequest = JsonRpcRequest<
 >;
 export type PaymentRequest = JsonRpcRequest<"pay", PaymentPayload>;
 export type CounterChallengeRequest = JsonRpcRequest<
-  "pay",
+  "counter_challenge",
   CounterChallengePayload
 >;
 
@@ -156,7 +161,7 @@ export type ReceiveVoucherRequest = JsonRpcRequest<"receive_voucher", Voucher>;
 export type GetAuthTokenResponse = JsonRpcResponse<string>;
 export type GetPaymentChannelResponse = JsonRpcResponse<PaymentChannelInfo>;
 export type PaymentResponse = JsonRpcResponse<PaymentPayload>;
-export type CounterChallengeResponse = JsonRpcResponse<CounterChallengePayload>;
+export type CounterChallengeResponse = JsonRpcResponse<CounterChallengeResult>;
 export type GetLedgerChannelResponse = JsonRpcResponse<LedgerChannelInfo>;
 export type VirtualFundResponse = JsonRpcResponse<ObjectiveResponse>;
 export type VersionResponse = JsonRpcResponse<string>;

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -53,8 +53,8 @@ export type PaymentPayload = {
 };
 
 export enum CounterChallengeAction {
-  Checkpoint,
-  CounterChallenge,
+  checkpoint,
+  challenge,
 }
 
 export type CounterChallengePayload = {

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -52,6 +52,19 @@ export type PaymentPayload = {
   Channel: string;
 };
 
+export enum CounterChallengeAction {
+  CounterChallenge = "counterChallenge",
+  Checkpoint = "checkpoint",
+  LiquidateAssets = "liquidateAssets",
+  DoNothing = "doNothing"
+}
+
+export type CounterChallengePayload = {
+  Channel: string;
+  Action: CounterChallengeAction
+};
+
+
 export type Voucher = {
   ChannelId: string;
   // todo: this should be a bigint
@@ -97,6 +110,8 @@ export type DirectFundRequest = JsonRpcRequest<
   DirectFundPayload
 >;
 export type PaymentRequest = JsonRpcRequest<"pay", PaymentPayload>;
+export type CounterChallengeRequest = JsonRpcRequest<"pay", CounterChallengePayload>;
+
 export type VirtualFundRequest = JsonRpcRequest<
   "create_payment_channel",
   VirtualFundPayload
@@ -141,6 +156,7 @@ export type ReceiveVoucherRequest = JsonRpcRequest<"receive_voucher", Voucher>;
 export type GetAuthTokenResponse = JsonRpcResponse<string>;
 export type GetPaymentChannelResponse = JsonRpcResponse<PaymentChannelInfo>;
 export type PaymentResponse = JsonRpcResponse<PaymentPayload>;
+export type CounterChallengeResponse = JsonRpcResponse<CounterChallengePayload>;
 export type GetLedgerChannelResponse = JsonRpcResponse<LedgerChannelInfo>;
 export type VirtualFundResponse = JsonRpcResponse<ObjectiveResponse>;
 export type VersionResponse = JsonRpcResponse<string>;
@@ -168,6 +184,7 @@ export type RPCRequestAndResponses = {
   get_ledger_channel: [GetLedgerChannelRequest, GetLedgerChannelResponse];
   get_payment_channel: [GetPaymentChannelRequest, GetPaymentChannelResponse];
   pay: [PaymentRequest, PaymentResponse];
+  counter_challenge: [CounterChallengeRequest, CounterChallengeResponse]
   close_payment_channel: [VirtualDefundRequest, VirtualDefundResponse];
   get_all_ledger_channels: [
     GetAllLedgerChannelsRequest,

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -59,9 +59,8 @@ export enum CounterChallengeAction {
 
 export type CounterChallengePayload = {
   Channel: string;
-  Action: CounterChallengeAction
+  Action: CounterChallengeAction;
 };
-
 
 export type Voucher = {
   ChannelId: string;
@@ -108,7 +107,10 @@ export type DirectFundRequest = JsonRpcRequest<
   DirectFundPayload
 >;
 export type PaymentRequest = JsonRpcRequest<"pay", PaymentPayload>;
-export type CounterChallengeRequest = JsonRpcRequest<"pay", CounterChallengePayload>;
+export type CounterChallengeRequest = JsonRpcRequest<
+  "pay",
+  CounterChallengePayload
+>;
 
 export type VirtualFundRequest = JsonRpcRequest<
   "create_payment_channel",
@@ -182,7 +184,7 @@ export type RPCRequestAndResponses = {
   get_ledger_channel: [GetLedgerChannelRequest, GetLedgerChannelResponse];
   get_payment_channel: [GetPaymentChannelRequest, GetPaymentChannelResponse];
   pay: [PaymentRequest, PaymentResponse];
-  counter_challenge: [CounterChallengeRequest, CounterChallengeResponse]
+  counter_challenge: [CounterChallengeRequest, CounterChallengeResponse];
   close_payment_channel: [VirtualDefundRequest, VirtualDefundResponse];
   get_all_ledger_channels: [
     GetAllLedgerChannelsRequest,

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
@@ -284,7 +283,7 @@ func (o *Objective) crankWithChallenge(updated Objective, sideEffects protocols.
 	}
 
 	// Liquidate the assets
-	if updated.C.GetChannelMode() == channel.Finalized && !updated.withdrawTransactionSubmitted && !updated.fullyWithdrawn() {
+	if updated.C.GetChannelMode() == channel.Finalized && !updated.withdrawTransactionSubmitted && !updated.FullyWithdrawn() {
 		latestSupportedSignedState, _ := updated.C.LatestSupportedSignedState()
 		transferTx := protocols.NewTransferAllTransaction(updated.C.Id, latestSupportedSignedState)
 		sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, transferTx)
@@ -293,8 +292,7 @@ func (o *Objective) crankWithChallenge(updated Objective, sideEffects protocols.
 	}
 
 	// Direct defund with challenge objective is complete after asset liquidation
-	if updated.C.GetChannelMode() == channel.Finalized && updated.fullyWithdrawn() {
-		updated.C.OnChain.FinalizesAt = common.Big0
+	if updated.C.GetChannelMode() == channel.Finalized && updated.FullyWithdrawn() {
 		updated.Status = protocols.Completed
 		return &updated, sideEffects, WaitingForNothing, nil
 	}
@@ -341,7 +339,7 @@ func (o *Objective) crank(updated Objective, sideEffects protocols.SideEffects, 
 	}
 
 	// Withdrawal of funds
-	if !updated.fullyWithdrawn() {
+	if !updated.FullyWithdrawn() {
 		// The first participant in the channel submits the withdrawAll transaction
 		if updated.C.MyIndex == 0 && !updated.withdrawTransactionSubmitted {
 			withdrawAll := protocols.NewWithdrawAllTransaction(updated.C.Id, latestSignedState)
@@ -375,8 +373,8 @@ func CreateChannelFromConsensusChannel(cc consensus_channel.ConsensusChannel) (*
 	return c, nil
 }
 
-// fullyWithdrawn returns true if the channel contains no assets on chain
-func (o *Objective) fullyWithdrawn() bool {
+// FullyWithdrawn returns true if the channel contains no assets on chain
+func (o *Objective) FullyWithdrawn() bool {
 	return !o.C.OnChain.Holdings.IsNonZero()
 }
 

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -19,10 +19,12 @@ import (
 )
 
 const (
-	WaitingForFinalization protocols.WaitingFor = "WaitingForFinalization"
-	WaitingForWithdraw     protocols.WaitingFor = "WaitingForWithdraw"
-	WaitingForChallenge    protocols.WaitingFor = "WaitingForChallenge"
-	WaitingForNothing      protocols.WaitingFor = "WaitingForNothing" // Finished
+	WaitingForFinalization     protocols.WaitingFor = "WaitingForFinalization"
+	WaitingForCounterChallenge protocols.WaitingFor = "WaitingForCounterChallenge"
+	WaitingForWithdraw         protocols.WaitingFor = "WaitingForWithdraw"
+	WaitingForChallenge        protocols.WaitingFor = "WaitingForChallenge"
+	WaitingForChallengeCleared protocols.WaitingFor = "WaitingForChallengeCleared"
+	WaitingForNothing          protocols.WaitingFor = "WaitingForNothing" // Finished
 )
 
 const (
@@ -50,6 +52,12 @@ type Objective struct {
 
 	IsChallengeInitiatedByMe      bool
 	challengeTransactionSubmitted bool
+
+	IsCheckpointInitiatedByMe      bool
+	checkpointTransactionSubmitted bool
+
+	CounterChallengeAction  types.CounterChallengeAction
+	waitForCounterChallenge bool
 }
 
 // isInConsensusOrFinalState returns true if the channel has a final state or latest state that is supported
@@ -129,6 +137,7 @@ func NewObjective(
 	}
 
 	init.IsChallengeInitiatedByMe = request.IsChallenge
+
 	return init, nil
 }
 

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	WaitingForFinalization     protocols.WaitingFor = "WaitingForFinalization"
-	WaitingForCounterChallenge protocols.WaitingFor = "WaitingForCounterChallenge"
 	WaitingForWithdraw         protocols.WaitingFor = "WaitingForWithdraw"
 	WaitingForChallenge        protocols.WaitingFor = "WaitingForChallenge"
 	WaitingForChallengeCleared protocols.WaitingFor = "WaitingForChallengeCleared"
@@ -53,11 +52,8 @@ type Objective struct {
 	IsChallengeInitiatedByMe      bool
 	challengeTransactionSubmitted bool
 
-	IsCheckpointInitiatedByMe      bool
+	IsCheckpoint                   bool
 	checkpointTransactionSubmitted bool
-
-	CounterChallengeAction  types.CounterChallengeAction
-	waitForCounterChallenge bool
 }
 
 // isInConsensusOrFinalState returns true if the channel has a final state or latest state that is supported
@@ -375,8 +371,13 @@ func (o *Objective) clone() Objective {
 	clone.C = cClone
 	clone.finalTurnNum = o.finalTurnNum
 	clone.withdrawTransactionSubmitted = o.withdrawTransactionSubmitted
+
 	clone.IsChallengeInitiatedByMe = o.IsChallengeInitiatedByMe
 	clone.challengeTransactionSubmitted = o.challengeTransactionSubmitted
+
+	clone.IsCheckpoint = o.IsCheckpoint
+	clone.checkpointTransactionSubmitted = o.checkpointTransactionSubmitted
+
 	return clone
 }
 

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -132,7 +132,6 @@ func NewObjective(
 	}
 
 	init.IsChallengeInitiatedByMe = request.IsChallenge
-
 	return init, nil
 }
 
@@ -449,7 +448,8 @@ func (o *Objective) otherParticipants() []types.Address {
 	return others
 }
 
-func (o *Objective) CreateConsensusChannel() (*consensus_channel.ConsensusChannel, error) {
+// CreateConsensusChannelFromChannel creates a ConsensusChannel from the Objective by extracting signatures and a single asset outcome from the latest supported signed state.
+func (o *Objective) CreateConsensusChannelFromChannel() (*consensus_channel.ConsensusChannel, error) {
 	ledger := o.C
 
 	signedState, err := ledger.LatestSupportedSignedState()

--- a/protocols/directdefund/serde.go
+++ b/protocols/directdefund/serde.go
@@ -11,12 +11,16 @@ import (
 // jsonObjective replaces the directdefund.Objective's channel pointer with
 // the channel's ID, making jsonObjective suitable for serialization
 type jsonObjective struct {
-	Status                        protocols.ObjectiveStatus
-	C                             types.Destination
-	FinalTurnNum                  uint64
-	TransactionSumbmitted         bool
-	IsChallengeInitiatedByMe      bool
-	ChallengeTransactionSubmitted bool
+	Status                         protocols.ObjectiveStatus
+	C                              types.Destination
+	FinalTurnNum                   uint64
+	TransactionSumbmitted          bool
+	IsChallengeInitiatedByMe       bool
+	ChallengeTransactionSubmitted  bool
+	CounterChallengeAction         types.CounterChallengeAction
+	IsCheckpointInitiatedByMe      bool
+	checkpointTransactionSubmitted bool
+	waitForCounterChallenge        bool
 }
 
 // MarshalJSON returns a JSON representation of the DirectDefundObjective
@@ -30,6 +34,10 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 		o.withdrawTransactionSubmitted,
 		o.IsChallengeInitiatedByMe,
 		o.challengeTransactionSubmitted,
+		o.CounterChallengeAction,
+		o.checkpointTransactionSubmitted,
+		o.IsCheckpointInitiatedByMe,
+		o.waitForCounterChallenge,
 	}
 
 	return json.Marshal(jsonDDFO)
@@ -58,6 +66,10 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.withdrawTransactionSubmitted = jsonDDFO.TransactionSumbmitted
 	o.IsChallengeInitiatedByMe = jsonDDFO.IsChallengeInitiatedByMe
 	o.challengeTransactionSubmitted = jsonDDFO.ChallengeTransactionSubmitted
+	o.CounterChallengeAction = jsonDDFO.CounterChallengeAction
+	o.checkpointTransactionSubmitted = jsonDDFO.checkpointTransactionSubmitted
+	o.IsCheckpointInitiatedByMe = jsonDDFO.IsCheckpointInitiatedByMe
+	o.waitForCounterChallenge = jsonDDFO.waitForCounterChallenge
 
 	return nil
 }

--- a/protocols/directdefund/serde.go
+++ b/protocols/directdefund/serde.go
@@ -17,10 +17,8 @@ type jsonObjective struct {
 	TransactionSumbmitted          bool
 	IsChallengeInitiatedByMe       bool
 	ChallengeTransactionSubmitted  bool
-	CounterChallengeAction         types.CounterChallengeAction
-	IsCheckpointInitiatedByMe      bool
-	checkpointTransactionSubmitted bool
-	waitForCounterChallenge        bool
+	IsCheckpoint                   bool
+	CheckpointTransactionSubmitted bool
 }
 
 // MarshalJSON returns a JSON representation of the DirectDefundObjective
@@ -34,10 +32,8 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 		o.withdrawTransactionSubmitted,
 		o.IsChallengeInitiatedByMe,
 		o.challengeTransactionSubmitted,
-		o.CounterChallengeAction,
 		o.checkpointTransactionSubmitted,
-		o.IsCheckpointInitiatedByMe,
-		o.waitForCounterChallenge,
+		o.IsCheckpoint,
 	}
 
 	return json.Marshal(jsonDDFO)
@@ -66,10 +62,8 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.withdrawTransactionSubmitted = jsonDDFO.TransactionSumbmitted
 	o.IsChallengeInitiatedByMe = jsonDDFO.IsChallengeInitiatedByMe
 	o.challengeTransactionSubmitted = jsonDDFO.ChallengeTransactionSubmitted
-	o.CounterChallengeAction = jsonDDFO.CounterChallengeAction
-	o.checkpointTransactionSubmitted = jsonDDFO.checkpointTransactionSubmitted
-	o.IsCheckpointInitiatedByMe = jsonDDFO.IsCheckpointInitiatedByMe
-	o.waitForCounterChallenge = jsonDDFO.waitForCounterChallenge
+	o.checkpointTransactionSubmitted = jsonDDFO.CheckpointTransactionSubmitted
+	o.IsCheckpoint = jsonDDFO.IsCheckpoint
 
 	return nil
 }

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -55,10 +55,9 @@ type PaymentRequest struct {
 	Channel types.Destination
 }
 
-// TODO: Check can we reuse type present in types package
 type CounterChallengeRequest struct {
-	Channel types.Destination
-	Action  types.CounterChallengeAction
+	ChannelId types.Destination
+	Action    types.CounterChallengeAction
 }
 
 type GetPaymentChannelRequest struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -30,6 +30,7 @@ const (
 	GetAllLedgerChannelsMethod        RequestMethod = "get_all_ledger_channels"
 	CreateVoucherRequestMethod        RequestMethod = "create_voucher"
 	ReceiveVoucherRequestMethod       RequestMethod = "receive_voucher"
+	CounterChallengeRequestMethod     RequestMethod = "counter_challenge"
 )
 
 type NotificationMethod string
@@ -53,6 +54,13 @@ type PaymentRequest struct {
 	Amount  uint64
 	Channel types.Destination
 }
+
+// TODO: Check can we reuse type present in types package
+type CounterChallengeRequest struct {
+	Channel types.Destination
+	Action  types.CounterChallengeAction
+}
+
 type GetPaymentChannelRequest struct {
 	Id types.Destination
 }
@@ -78,7 +86,8 @@ type RequestPayload interface {
 		GetPaymentChannelRequest |
 		GetPaymentChannelsByLedgerRequest |
 		NoPayloadRequest |
-		payments.Voucher
+		payments.Voucher |
+		CounterChallengeRequest
 }
 
 type NotificationPayload interface {
@@ -116,7 +125,8 @@ type ResponsePayload interface {
 		payments.Voucher |
 		common.Address |
 		string |
-		payments.ReceiveVoucherSummary
+		payments.ReceiveVoucherSummary |
+		CounterChallengeRequest
 }
 
 type JsonRpcSuccessResponse[T ResponsePayload] struct {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -187,7 +187,7 @@ func (rs *RpcServer) registerHandlers() (err error) {
 			})
 		case serde.CounterChallengeRequestMethod:
 			return processRequest(rs, permSign, requestData, func(req serde.CounterChallengeRequest) (serde.CounterChallengeRequest, error) {
-				rs.node.CounterChallenge(req.Channel, req.Action)
+				rs.node.CounterChallenge(req.ChannelId, req.Action)
 				return req, nil
 			})
 		default:

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -185,6 +185,11 @@ func (rs *RpcServer) registerHandlers() (err error) {
 				}
 				return rs.node.GetPaymentChannelsByLedger(req.LedgerId)
 			})
+		case serde.CounterChallengeRequestMethod:
+			return processRequest(rs, permSign, requestData, func(req serde.CounterChallengeRequest) (serde.CounterChallengeRequest, error) {
+				rs.node.CounterChallenge(req.Channel, req.Action)
+				return req, nil
+			})
 		default:
 			errRes := serde.NewJsonRpcErrorResponse(jsonrpcReq.Id, serde.MethodNotFoundError)
 			return marshalResponse(errRes)

--- a/types/types.go
+++ b/types/types.go
@@ -32,3 +32,18 @@ type Funds map[common.Address]*big.Int
 type ConstError string
 
 func (c ConstError) Error() string { return string(c) }
+
+type CounterChallengeAction int
+
+const (
+	// TODO: Check DoNothing is necessary or not
+	DoNothing CounterChallengeAction = iota
+	Checkpoint
+	CounterChallenge
+	LiquidateAssets
+)
+
+type CounterChallengeRequest struct {
+	ChannelId Destination
+	Action    CounterChallengeAction
+}

--- a/types/types.go
+++ b/types/types.go
@@ -36,11 +36,8 @@ func (c ConstError) Error() string { return string(c) }
 type CounterChallengeAction int
 
 const (
-	// TODO: Check DoNothing is necessary or not
-	DoNothing CounterChallengeAction = iota
-	Checkpoint
+	Checkpoint CounterChallengeAction = iota
 	CounterChallenge
-	LiquidateAssets
 )
 
 type CounterChallengeRequest struct {

--- a/types/types.go
+++ b/types/types.go
@@ -37,7 +37,7 @@ type CounterChallengeAction int
 
 const (
 	Checkpoint CounterChallengeAction = iota
-	CounterChallenge
+	Challenge
 )
 
 type CounterChallengeRequest struct {


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Update crank and channel to clear the registered challenge
- Add counter-challenge method in CLI to either clear the challenge or raise a new challenge
- Handle challenge cleared event
