### PR TITLE
Break exponential back-off loop to resubscribe chain event logs and blocks on closing node

### DIFF
--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -492,7 +492,6 @@ func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventChan
 			resubscribed := false // Flag to indicate whether resubscription was successful
 
 			// Use exponential backoff loop to attempt to re-establish subscription
-		resubscriptionLoop:
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
 				select {
 				// Exit from resubscription loop on closing chain service (cancelling context)
@@ -517,12 +516,15 @@ func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventChan
 					}
 
 					resubscribed = true
-					break resubscriptionLoop
 
 				case <-ecs.ctx.Done():
 					ecs.wg.Done()
 					ecs.eventSub.Unsubscribe()
 					return
+				}
+
+				if resubscribed {
+					break
 				}
 			}
 
@@ -563,7 +565,6 @@ func (ecs *EthChainService) listenForNewBlocks(errorChan chan<- error, newBlockC
 			// Use exponential backoff loop to attempt to re-establish subscription
 			resubscribed := false // Flag to indicate whether resubscription was successful
 
-		resubscriptionLoop:
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
 				select {
 				// Exit from resubscription loop on closing chain service (cancelling context)
@@ -578,12 +579,15 @@ func (ecs *EthChainService) listenForNewBlocks(errorChan chan<- error, newBlockC
 					ecs.newBlockSub = newBlockSub
 					ecs.logger.Debug("resubscribed to chain new blocks")
 					resubscribed = true
-					break resubscriptionLoop
 
 				case <-ecs.ctx.Done():
 					ecs.newBlockSub.Unsubscribe()
 					ecs.wg.Done()
 					return
+				}
+
+				if resubscribed {
+					break
 				}
 			}
 

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -495,6 +495,8 @@ func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventChan
 		resubscriptionLoop:
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
 				select {
+				// Exit from resubscription loop on closing chain service (cancelling context)
+				// https://github.com/golang/go/issues/39483
 				case <-time.After(backoffTime):
 					eventSub, err := ecs.chain.SubscribeFilterLogs(ecs.ctx, eventQuery, eventChan)
 					if err != nil {
@@ -564,6 +566,8 @@ func (ecs *EthChainService) listenForNewBlocks(errorChan chan<- error, newBlockC
 		resubscriptionLoop:
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
 				select {
+				// Exit from resubscription loop on closing chain service (cancelling context)
+				// https://github.com/golang/go/issues/39483
 				case <-time.After(backoffTime):
 					newBlockSub, err := ecs.chain.SubscribeNewHead(ecs.ctx, newBlockChan)
 					if err != nil {

--- a/node/engine/chainservice/l2_chainservice.go
+++ b/node/engine/chainservice/l2_chainservice.go
@@ -210,6 +210,8 @@ func (l2cs *L2ChainService) listenForEventLogs(errorChan chan<- error, eventChan
 		resubscriptionLoop:
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
 				select {
+				// Exit from resubscription loop on closing chain service (cancelling context)
+				// https://github.com/golang/go/issues/39483
 				case <-time.After(backoffTime):
 					eventSub, err := l2cs.chain.SubscribeFilterLogs(l2cs.ctx, eventQuery, eventChan)
 					if err != nil {
@@ -279,6 +281,8 @@ func (l2cs *L2ChainService) listenForNewBlocks(errorChan chan<- error, newBlockC
 		resubscriptionLoop:
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
 				select {
+				// Exit from resubscription loop on closing chain service (cancelling context)
+				// https://github.com/golang/go/issues/39483
 				case <-time.After(backoffTime):
 					newBlockSub, err := l2cs.chain.SubscribeNewHead(l2cs.ctx, newBlockChan)
 					if err != nil {

--- a/node/engine/chainservice/l2_chainservice.go
+++ b/node/engine/chainservice/l2_chainservice.go
@@ -207,7 +207,6 @@ func (l2cs *L2ChainService) listenForEventLogs(errorChan chan<- error, eventChan
 			resubscribed := false // Flag to indicate whether resubscription was successful
 
 			// Use exponential backoff loop to attempt to re-establish subscription
-		resubscriptionLoop:
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
 				select {
 				// Exit from resubscription loop on closing chain service (cancelling context)
@@ -232,12 +231,15 @@ func (l2cs *L2ChainService) listenForEventLogs(errorChan chan<- error, eventChan
 					}
 
 					resubscribed = true
-					break resubscriptionLoop
 
 				case <-l2cs.ctx.Done():
 					l2cs.wg.Done()
 					l2cs.eventSub.Unsubscribe()
 					return
+				}
+
+				if resubscribed {
+					break
 				}
 			}
 
@@ -278,7 +280,6 @@ func (l2cs *L2ChainService) listenForNewBlocks(errorChan chan<- error, newBlockC
 			// Use exponential backoff loop to attempt to re-establish subscription
 			resubscribed := false // Flag to indicate whether resubscription was successful
 
-		resubscriptionLoop:
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
 				select {
 				// Exit from resubscription loop on closing chain service (cancelling context)
@@ -293,12 +294,15 @@ func (l2cs *L2ChainService) listenForNewBlocks(errorChan chan<- error, newBlockC
 					l2cs.newBlockSub = newBlockSub
 					l2cs.logger.Debug("resubscribed to chain new blocks")
 					resubscribed = true
-					break resubscriptionLoop
 
 				case <-l2cs.ctx.Done():
 					l2cs.newBlockSub.Unsubscribe()
 					l2cs.wg.Done()
 					return
+				}
+
+				if resubscribed {
+					break
 				}
 			}
 


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Resolve issue in go-nitro where it is unable to stop the node after a chain disconnect
  - Refactor resubscription loop to break when context is cancelled (node is closed)