### PR TITLE
Add durable store in the bridge to persist data

### DIFF
--- a/bridge/durablestore.go
+++ b/bridge/durablestore.go
@@ -93,16 +93,16 @@ func (ds *DurableStore) GetMirrorChannelDetailsByL1Channel(l1ChannelId types.Des
 			var mirrorChannelDetails MirrorChannelDetails
 			err := json.Unmarshal([]byte(chJSON), &mirrorChannelDetails)
 			if err != nil {
-				return true // not found, continue looking
+				return true // target not found, continue looking
 			}
 
 			if mirrorChannelDetails.L1ChannelId == l1ChannelId {
 				l2ChannelId = types.Destination(common.HexToHash(key))
 				isCreated = mirrorChannelDetails.IsCreated
-				return false // we have found the target: break the Range loop
+				return false // we have found the target, break the Range loop
 			}
 
-			return true // not found: continue looking
+			return true // target not found, continue looking
 		})
 	})
 	if err != nil {

--- a/bridge/durablestore.go
+++ b/bridge/durablestore.go
@@ -1,14 +1,22 @@
 package bridge
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/types"
 	"github.com/tidwall/buntdb"
 )
 
-const BRIDGE_DURABLE_STORE_SUB_DIR = "bridge-store"
+const BRIDGE_DURABLE_STORE_SUB_DIR = "bridge"
+
+type MirrorChannelDetails struct {
+	L1ChannelId types.Destination
+	IsCreated   bool
+}
 
 type DurableStore struct {
 	mirrorChannels *buntdb.DB
@@ -44,6 +52,64 @@ func (ds *DurableStore) openDB(name string, config buntdb.Config) (*buntdb.DB, e
 		return nil, err
 	}
 	return db, nil
+}
+
+func (ds *DurableStore) SetMirrorChannelDetails(l2ChannelId types.Destination, mirrorChannelDetails MirrorChannelDetails) error {
+	mirrorChannelDetailsJson, err := json.Marshal(mirrorChannelDetails)
+	if err != nil {
+		return err
+	}
+
+	err = ds.mirrorChannels.Update(func(tx *buntdb.Tx) error {
+		_, _, err := tx.Set(l2ChannelId.String(), string(mirrorChannelDetailsJson), nil)
+		return err
+	})
+	return err
+}
+
+func (ds *DurableStore) GetMirrorChannelDetails(l2ChannelId types.Destination) (mirrorChannelDetails MirrorChannelDetails, err error) {
+	var mirrorChannelDetailsJson string
+
+	err = ds.mirrorChannels.View(func(tx *buntdb.Tx) error {
+		var err error
+		mirrorChannelDetailsJson, err = tx.Get(l2ChannelId.String())
+		return err
+	})
+	if err != nil {
+		return mirrorChannelDetails, err
+	}
+
+	err = json.Unmarshal([]byte(mirrorChannelDetailsJson), &mirrorChannelDetails)
+	if err != nil {
+		return mirrorChannelDetails, err
+	}
+
+	return mirrorChannelDetails, nil
+}
+
+func (ds *DurableStore) GetMirrorChannelDetailsByL1Channel(l1ChannelId types.Destination) (l2ChannelId types.Destination, isCreated bool, err error) {
+	err = ds.mirrorChannels.View(func(tx *buntdb.Tx) error {
+		return tx.Ascend("", func(key, chJSON string) bool {
+			var mirrorChannelDetails MirrorChannelDetails
+			err := json.Unmarshal([]byte(chJSON), &mirrorChannelDetails)
+			if err != nil {
+				return true // not found, continue looking
+			}
+
+			if mirrorChannelDetails.L1ChannelId == l1ChannelId {
+				l2ChannelId = types.Destination(common.HexToHash(key))
+				isCreated = mirrorChannelDetails.IsCreated
+				return false // we have found the target: break the Range loop
+			}
+
+			return true // not found: continue looking
+		})
+	})
+	if err != nil {
+		return l2ChannelId, isCreated, err
+	}
+
+	return l2ChannelId, isCreated, nil
 }
 
 func (ds *DurableStore) Close() error {

--- a/bridge/durablestore.go
+++ b/bridge/durablestore.go
@@ -1,0 +1,51 @@
+package bridge
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tidwall/buntdb"
+)
+
+const BRIDGE_DURABLE_STORE_SUB_DIR = "bridge-store"
+
+type DurableStore struct {
+	mirrorChannels *buntdb.DB
+	folder         string // the folder where the store's data is stored
+}
+
+func NewDurableStore(folder string, config buntdb.Config) (*DurableStore, error) {
+	dataFolder := filepath.Join(folder, BRIDGE_DURABLE_STORE_SUB_DIR)
+	ds := DurableStore{}
+
+	err := os.MkdirAll(dataFolder, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	ds.folder = dataFolder
+
+	ds.mirrorChannels, err = ds.openDB("mirror_channels", config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ds, nil
+}
+
+func (ds *DurableStore) openDB(name string, config buntdb.Config) (*buntdb.DB, error) {
+	db, err := buntdb.Open(fmt.Sprintf("%s/%s.db", ds.folder, name))
+	if err != nil {
+		return nil, err
+	}
+	err = db.SetConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+func (ds *DurableStore) Close() error {
+	return ds.mirrorChannels.Close()
+}

--- a/bridge/durablestore_test.go
+++ b/bridge/durablestore_test.go
@@ -1,0 +1,52 @@
+package bridge_test
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/bridge"
+	"github.com/statechannels/go-nitro/internal/testhelpers"
+	"github.com/statechannels/go-nitro/types"
+	"github.com/tidwall/buntdb"
+)
+
+func TestSetGetMirrorChannels(t *testing.T) {
+	dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
+	defer cleanup()
+	durableStore, err := bridge.NewDurableStore(dataFolder, buntdb.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l1ChannelId := types.Destination(common.HexToHash("0x59846efc80336b0961e4f84a0d974967bfeb04a9b17d90b4610b1a968f00efcd"))
+	l2ChannelId := types.Destination(common.HexToHash("0x53494de9354193e864d545e7edfb3915e8b1e210fe4b57585055dff17b2abd30"))
+	mirrorChannelDetail := bridge.MirrorChannelDetails{L1ChannelId: l1ChannelId, IsCreated: true}
+
+	err = durableStore.SetMirrorChannelDetails(l2ChannelId, mirrorChannelDetail)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := durableStore.GetMirrorChannelDetails(l2ChannelId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(got, mirrorChannelDetail); diff != "" {
+		t.Fatalf("fetched result different than expected %s", diff)
+	}
+
+	testL2ChannelId, testIscreated, err := durableStore.GetMirrorChannelDetailsByL1Channel(l1ChannelId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(l2ChannelId, testL2ChannelId); diff != "" {
+		t.Fatalf("fetched result different than expected %s", diff)
+	}
+
+	if diff := cmp.Diff(testIscreated, mirrorChannelDetail.IsCreated); diff != "" {
+		t.Fatalf("fetched result different than expected %s", diff)
+	}
+}

--- a/cmd/start-bridge/main.go
+++ b/cmd/start-bridge/main.go
@@ -179,6 +179,9 @@ func main() {
 		Flags:  flags,
 		Before: altsrc.InitInputSourceWithContext(flags, altsrc.NewTomlSourceFromFlagFunc(CONFIG)),
 		Action: func(cCtx *cli.Context) error {
+			chainpk = utils.TrimHexPrefix(chainpk)
+			statechannelpk = utils.TrimHexPrefix(statechannelpk)
+
 			// Variable to hold the deserialized data
 			var assets bridge.L1ToL2AssetConfig
 

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -81,4 +82,13 @@ func WaitForRpcClient(rpcClientUrl string, interval, timeout time.Duration) erro
 			}
 		}
 	}
+}
+
+// TrimHexPrefix removes the '0x' prefix from a hexadecimal string if it exists.
+// If the string does not start with '0x', it returns the original string.
+func TrimHexPrefix(hex string) string {
+	if strings.HasPrefix(hex, "0x") {
+		return strings.TrimPrefix(hex, "0x")
+	}
+	return hex
 }

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/cmd/utils"
 	"github.com/statechannels/go-nitro/internal/logging"
 	nodeUtils "github.com/statechannels/go-nitro/internal/node"
 	"github.com/statechannels/go-nitro/internal/rpc"
@@ -224,6 +225,9 @@ func main() {
 		Flags:  flags,
 		Before: altsrc.InitInputSourceWithContext(flags, altsrc.NewTomlSourceFromFlagFunc(CONFIG)),
 		Action: func(cCtx *cli.Context) error {
+			chainPk = utils.TrimHexPrefix(chainPk)
+			pkString = utils.TrimHexPrefix(pkString)
+
 			storeOpts := store.StoreOpts{
 				PkBytes:            common.Hex2Bytes(pkString),
 				UseDurableStore:    useDurableStore,

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -105,7 +105,7 @@ func TestBridgedFund(t *testing.T) {
 
 		// Wait for mirror channel to be created
 		completedMirrorChannel := <-bridge.CompletedMirrorChannels()
-		l2LedgerChannelId, _ = bridge.GetMirrorChannel(l1LedgerChannelResponse.ChannelId)
+		l2LedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
 		testhelpers.Assert(t, completedMirrorChannel == l2LedgerChannelId, "Expects mirror channel id to be %v", l2LedgerChannelId)
 		checkLedgerChannel(t, l1LedgerChannelResponse.ChannelId, initialLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, types.Address{}), query.Open, nodeA)
 		checkLedgerChannel(t, l2LedgerChannelId, initialLedgerOutcome(bridgeAddress, *nodeAPrime.Address, 0, ledgerChannelDeposit, types.Address{}), query.Open, nodeAPrime)


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Add setter and getter for storing and retrieving l2tol1 channel information
- Add test for durable store methods
- Remove the `0x` prefix from private keys if it is present