### PR TITLE
Retry approve tx with higher gas limit if transaction event is not emitted

### DIFF
--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -310,11 +310,11 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 					case newBlock := <-ecs.newBlockChan:
 						if (newBlock.Number.Int64() - currentBLock.Number.Int64()) > BLOCKS_WITHOUT_EVENT_THRESHOLD {
 							if isApproveTxRetried {
-								slog.Error("reached max retry limit for sending Approve transaction", "txTurnNumber", isApproveTxRetried)
+								slog.Error("event Approval was not emitted after retrying")
 								return nil
 							}
 
-							slog.Error("event Approval was not emitted, retrying with higher gas limit", "approveTxHash", approveTx.Hash().String())
+							slog.Error("event Approval was not emitted", "approveTxHash", approveTx.Hash().String())
 
 							// Estimate gas for new Approve transaction
 							parsedABI, err := abi.JSON(strings.NewReader(Token.TokenABI))
@@ -349,6 +349,8 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 							}
 
 							isApproveTxRetried = true
+							currentBLock = newBlock
+
 							slog.Info("Resubmitted transaction with higher gas limit", "gasLimit", approveTxOpts.GasLimit, "approveTxHash", reApproveTx.Hash().String())
 						}
 					}

--- a/node/engine/chainservice/l2_chainservice.go
+++ b/node/engine/chainservice/l2_chainservice.go
@@ -87,12 +87,14 @@ func newL2ChainService(chain ethChain, startBlockNum uint64, bridge *Bridge.Brid
 	tracker := NewEventTracker(startBlock)
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
-	ecs := EthChainService{chain, nil, common.Address{}, caAddress, vpaAddress, txSigner, make(chan Event, 10), logger, ctx, cancelCtx, &sync.WaitGroup{}, tracker, nil, nil}
+	ecs := EthChainService{chain, nil, common.Address{}, caAddress, vpaAddress, txSigner, make(chan Event, 10), logger, ctx, cancelCtx, &sync.WaitGroup{}, tracker, nil, nil, nil}
 	l2cs := L2ChainService{&ecs, bridge, bridgeAddress}
 	errChan, newBlockChan, eventChan, eventQuery, err := l2cs.subscribeForLogs()
 	if err != nil {
 		return nil, err
 	}
+
+	l2cs.newBlockChan = newBlockChan
 
 	// Prevent go routines from processing events before checkForMissedEvents completes
 	l2cs.eventTracker.mu.Lock()


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)

- Wait for ERC20 approve tx event for 16 blocks (`BLOCKS_WITHOUT_EVENT_THRESHOLD`)
- If event not emitted, retry transaction with higher gas limit