### PR TITLE
Handle node panics in P2P communication and virtual fund

### DIFF
--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -657,16 +657,18 @@ func (e *Engine) handleCounterChallengeRequest(request types.CounterChallengeReq
 
 // sendMessages sends out the messages and records the metrics.
 func (e *Engine) sendMessages(msgs []protocols.Message) {
+	defer e.wg.Done()
 	for _, message := range msgs {
 		message.From = *e.store.GetAddress()
 		err := e.msg.Send(message)
 		if err != nil {
+			e.logger.Error("could not send message", "message", message.Summarize())
 			e.logger.Error(err.Error())
-			panic(err)
+
+			return
 		}
 		e.logMessage(message, Outgoing)
 	}
-	e.wg.Done()
 }
 
 // executeSideEffects executes the SideEffects declared by cranking an Objective or handling a payment request.

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -57,6 +57,7 @@ var nonFatalErrors = []error{
 	&ErrGetObjective{},
 	store.ErrLoadVouchers,
 	directfund.ErrLedgerChannelExists,
+	virtualfund.ErrUpdatingLedgerFunding,
 }
 
 // Engine is the imperative part of the core business logic of a go-nitro Node

--- a/node/node.go
+++ b/node/node.go
@@ -300,7 +300,7 @@ func (n *Node) Pay(channelId types.Destination, amount *big.Int) error {
 	}
 
 	if types.Gt(amount, (*big.Int)(paymentChannel.Balance.RemainingFunds)) {
-		return fmt.Errorf("Error making payment request: insufficient funds")
+		return fmt.Errorf("error making payment request: insufficient funds")
 	}
 
 	// Send the event to the engine

--- a/node/node.go
+++ b/node/node.go
@@ -293,9 +293,19 @@ func (n *Node) CloseLedgerChannel(channelId types.Destination, isChallenge bool)
 }
 
 // Pay will send a signed voucher to the payee that they can redeem for the given amount.
-func (n *Node) Pay(channelId types.Destination, amount *big.Int) {
+func (n *Node) Pay(channelId types.Destination, amount *big.Int) error {
+	paymentChannel, err := n.GetPaymentChannel(channelId)
+	if err != nil {
+		return err
+	}
+
+	if types.Gt(amount, (*big.Int)(paymentChannel.Balance.RemainingFunds)) {
+		return fmt.Errorf("Error making payment request: insufficient funds")
+	}
+
 	// Send the event to the engine
 	n.engine.PaymentRequestsFromAPI <- engine.PaymentRequest{ChannelId: channelId, Amount: amount}
+	return nil
 }
 
 // GetPaymentChannel returns the payment channel with the given id.

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -119,7 +119,10 @@ func TestBridgedFund(t *testing.T) {
 		checkPaymentChannel(t, virtualResponse.ChannelId, virtualOutcome, query.Open, nodeAPrime)
 
 		// APrime pays BPrime
-		nodeAPrime.Pay(virtualResponse.ChannelId, big.NewInt(payAmount))
+		err := nodeAPrime.Pay(virtualResponse.ChannelId, big.NewInt(payAmount))
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Virtual defund
 		virtualDefundResponse, _ := nodeAPrime.ClosePaymentChannel(virtualResponse.ChannelId)
@@ -293,7 +296,10 @@ func TestExitL2WithPayments(t *testing.T) {
 		virtualChannel := createL2VirtualChannel(t, nodeAPrime, nodeBPrime, storeBPrime, tcL2)
 
 		// Bridge pays APrime
-		nodeBPrime.Pay(virtualChannel.Id, big.NewInt(payAmount))
+		err := nodeBPrime.Pay(virtualChannel.Id, big.NewInt(payAmount))
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Wait for APrime to recieve voucher
 		nodeAPrimeVoucher := <-nodeAPrime.ReceivedVouchers()
@@ -416,7 +422,10 @@ func TestExitL2WithLedgerChannelStateUnilaterally(t *testing.T) {
 	virtualChannel := createL2VirtualChannel(t, nodeAPrime, nodeBPrime, storeBPrime, tcL2)
 
 	// Bridge pays APrime
-	nodeBPrime.Pay(virtualChannel.Id, big.NewInt(payAmount))
+	err := nodeBPrime.Pay(virtualChannel.Id, big.NewInt(payAmount))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Wait for APrime to recieve voucher
 	nodeAPrimeVoucher := <-nodeAPrime.ReceivedVouchers()
@@ -534,7 +543,10 @@ func TestExitL2WithVirtualChannelStateUnilaterally(t *testing.T) {
 	virtualChannel := createL2VirtualChannel(t, nodeAPrime, nodeBPrime, storeBPrime, tcL2)
 
 	// Bridge pays APrime
-	nodeBPrime.Pay(virtualChannel.Id, big.NewInt(payAmount))
+	err := nodeBPrime.Pay(virtualChannel.Id, big.NewInt(payAmount))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Wait for APrime to recieve voucher
 	nodeAPrimeVoucher := <-nodeAPrime.ReceivedVouchers()

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -138,7 +138,11 @@ func TestCheckpoint(t *testing.T) {
 	}
 	waitForObjectives(t, nodeA, nodeB, []node.Node{}, []protocols.ObjectiveId{response.Id})
 	// Alice pays Bob
-	nodeA.Pay(response.ChannelId, big.NewInt(payAmount))
+	err = nodeA.Pay(response.ChannelId, big.NewInt(payAmount))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	nodeBVoucher := <-nodeB.ReceivedVouchers()
 	t.Logf("Voucher recieved %+v", nodeBVoucher)
 	virtualDefundResponse, err := nodeA.ClosePaymentChannel(response.ChannelId)
@@ -244,7 +248,11 @@ func TestCounterChallenge(t *testing.T) {
 	}
 	waitForObjectives(t, nodeA, nodeB, []node.Node{}, []protocols.ObjectiveId{response.Id})
 	// Alice pays Bob
-	nodeA.Pay(response.ChannelId, big.NewInt(payAmount))
+	err = nodeA.Pay(response.ChannelId, big.NewInt(payAmount))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	nodeBVoucher := <-nodeB.ReceivedVouchers()
 	t.Logf("Voucher recieved %+v", nodeBVoucher)
 	virtualDefundResponse, err := nodeA.ClosePaymentChannel(response.ChannelId)
@@ -323,7 +331,10 @@ func TestVirtualPaymentChannel(t *testing.T) {
 	checkPaymentChannel(t, virtualResponse.ChannelId, virtualOutcome, query.Open, nodeA, nodeB)
 
 	// Alice pays Bob
-	nodeA.Pay(virtualResponse.ChannelId, big.NewInt(payAmount))
+	err := nodeA.Pay(virtualResponse.ChannelId, big.NewInt(payAmount))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Close Alice's node
 	closeNode(t, &nodeA)
@@ -559,7 +570,11 @@ func TestVirtualPaymentChannelWithObjective(t *testing.T) {
 	waitForObjectives(t, nodeA, nodeB, []node.Node{}, []protocols.ObjectiveId{response.Id})
 
 	paymentAmount := 2000
-	nodeB.Pay(response.ChannelId, big.NewInt(int64(paymentAmount)))
+	err = nodeB.Pay(response.ChannelId, big.NewInt(int64(paymentAmount)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	nodeAVoucher := <-nodeA.ReceivedVouchers()
 	t.Log("voucher recieved  for channel", nodeAVoucher.ChannelId)
 

--- a/node_test/integration_test.go
+++ b/node_test/integration_test.go
@@ -162,7 +162,10 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		// Send payments
 		for i := 0; i < len(virtualIds); i++ {
 			for j := 0; j < int(tc.NumOfPayments); j++ {
-				clientA.Pay(virtualIds[i], big.NewInt(int64(1)))
+				err = clientA.Pay(virtualIds[i], big.NewInt(int64(1)))
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 		}
 

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -437,7 +437,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		ledgerSideEffects, err := updated.updateLedgerWithGuarantee(*updated.ToMyLeft, secretKey)
 		if err != nil {
 			slog.Error("error updating ledger funding", "error", err)
-			return o, protocols.SideEffects{}, WaitingForNothing, ErrUpdatingLedgerFunding
+			return o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("%w: %w", ErrUpdatingLedgerFunding, err)
 		}
 		sideEffects.Merge(ledgerSideEffects)
 	}
@@ -446,7 +446,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		ledgerSideEffects, err := updated.updateLedgerWithGuarantee(*updated.ToMyRight, secretKey)
 		if err != nil {
 			slog.Error("error updating ledger funding", "error", err)
-			return o, protocols.SideEffects{}, WaitingForNothing, ErrUpdatingLedgerFunding
+			return o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("%w: %w", ErrUpdatingLedgerFunding, err)
 		}
 		sideEffects.Merge(ledgerSideEffects)
 	}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"math/big"
 	"strings"
 
@@ -436,7 +435,6 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 		ledgerSideEffects, err := updated.updateLedgerWithGuarantee(*updated.ToMyLeft, secretKey)
 		if err != nil {
-			slog.Error("error updating ledger funding", "error", err)
 			return o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("%w: %w", ErrUpdatingLedgerFunding, err)
 		}
 		sideEffects.Merge(ledgerSideEffects)
@@ -445,7 +443,6 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	if !updated.isBob() && !updated.ToMyRight.IsFundingTheTarget() {
 		ledgerSideEffects, err := updated.updateLedgerWithGuarantee(*updated.ToMyRight, secretKey)
 		if err != nil {
-			slog.Error("error updating ledger funding", "error", err)
 			return o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("%w: %w", ErrUpdatingLedgerFunding, err)
 		}
 		sideEffects.Merge(ledgerSideEffects)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"strings"
 
@@ -28,6 +29,8 @@ const (
 const (
 	SignedStatePayload protocols.PayloadType = "SignedStatePayload"
 )
+
+var ErrUpdatingLedgerFunding = errors.New("error updating ledger funding")
 
 const ObjectivePrefix = "VirtualFund-"
 
@@ -433,7 +436,8 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 		ledgerSideEffects, err := updated.updateLedgerWithGuarantee(*updated.ToMyLeft, secretKey)
 		if err != nil {
-			return o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("error updating ledger funding: %w", err)
+			slog.Error("error updating ledger funding", "error", err)
+			return o, protocols.SideEffects{}, WaitingForNothing, ErrUpdatingLedgerFunding
 		}
 		sideEffects.Merge(ledgerSideEffects)
 	}
@@ -441,7 +445,8 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	if !updated.isBob() && !updated.ToMyRight.IsFundingTheTarget() {
 		ledgerSideEffects, err := updated.updateLedgerWithGuarantee(*updated.ToMyRight, secretKey)
 		if err != nil {
-			return o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("error updating ledger funding: %w", err)
+			slog.Error("error updating ledger funding", "error", err)
+			return o, protocols.SideEffects{}, WaitingForNothing, ErrUpdatingLedgerFunding
 		}
 		sideEffects.Merge(ledgerSideEffects)
 	}

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"math/big"
 
@@ -144,17 +143,8 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 					return serde.PaymentRequest{}, err
 				}
 
-				paymentChannel, err := nrs.node.GetPaymentChannel(req.Channel)
-				if err != nil {
-					return serde.PaymentRequest{}, err
-				}
-
-				if types.Gt(big.NewInt(int64(req.Amount)), (*big.Int)(paymentChannel.Balance.RemainingFunds)) {
-					return serde.PaymentRequest{}, fmt.Errorf("Error making payment: unable to pay amount: insufficient funds")
-				}
-
-				nrs.node.Pay(req.Channel, big.NewInt(int64(req.Amount)))
-				return req, nil
+				err := nrs.node.Pay(req.Channel, big.NewInt(int64(req.Amount)))
+				return req, err
 			})
 		case serde.GetPaymentChannelRequestMethod:
 			return processRequest(nrs.BaseRpcServer, permRead, requestData, func(req serde.GetPaymentChannelRequest) (query.PaymentChannelInfo, error) {


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Prevent node panic due to error in sending P2P messages
- Return non fatal error if virtual fund errors out while updating underlying ledger channel
- Respond with error if `Pay` RPC request amount is more than remaining funds in payment channel