### PR TITLE
Implement bridged defund for L2 nodes

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -14,6 +14,7 @@ import (
 	"github.com/statechannels/go-nitro/node"
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/node/query"
+	"github.com/statechannels/go-nitro/protocols/bridgeddefund"
 	"github.com/statechannels/go-nitro/protocols/bridgedfund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/protocols/virtualdefund"
@@ -317,7 +318,11 @@ func (b *Bridge) processCompletedObjectivesFromL2(objId protocols.ObjectiveId) e
 				return fmt.Errorf("error in send transaction %w", err)
 			}
 		}
+
+	case *bridgeddefund.Objective:
+		// TODO: Call mirrorBridgeDefund in L1
 	}
+
 	return nil
 }
 

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -590,7 +590,7 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 		return e.attemptProgress(&bfo)
 
 	case bridgeddefund.ObjectiveRequest:
-		bdfo, err := bridgeddefund.NewObjective(request)
+		bdfo, err := bridgeddefund.NewObjective(request, true, e.store.GetConsensusChannelById)
 		if err != nil {
 			return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not create bridgeddefund objective for %+v: %w", request, err)
 		}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -24,6 +24,7 @@ import (
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/bridgeddefund"
 	"github.com/statechannels/go-nitro/protocols/bridgedfund"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
@@ -587,6 +588,13 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 			return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not create bridgedfund objective for %+v: %w", request, err)
 		}
 		return e.attemptProgress(&bfo)
+
+	case bridgeddefund.ObjectiveRequest:
+		bdfo, err := bridgeddefund.NewObjective(request)
+		if err != nil {
+			return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not create bridgeddefund objective for %+v: %w", request, err)
+		}
+		return e.attemptProgress(&bdfo)
 
 	default:
 		return failedEngineEvent, fmt.Errorf("handleAPIEvent: Unknown objective type %T", request)

--- a/node/engine/store/durablestore.go
+++ b/node/engine/store/durablestore.go
@@ -14,6 +14,7 @@ import (
 	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/bridgeddefund"
 	"github.com/statechannels/go-nitro/protocols/bridgedfund"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
@@ -635,6 +636,16 @@ func (ds *DurableStore) populateChannelData(obj protocols.Objective) error {
 		}
 		return nil
 	case *bridgedfund.Objective:
+		ch, err := ds.getChannelById(o.C.Id)
+		if err != nil {
+			return fmt.Errorf("error retrieving channel data for objective %s: %w", id, err)
+		}
+
+		o.C = &ch
+
+		return nil
+
+	case *bridgeddefund.Objective:
 		ch, err := ds.getChannelById(o.C.Id)
 		if err != nil {
 			return fmt.Errorf("error retrieving channel data for objective %s: %w", id, err)

--- a/node/engine/store/memstore.go
+++ b/node/engine/store/memstore.go
@@ -12,6 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/internal/safesync"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/bridgeddefund"
 	"github.com/statechannels/go-nitro/protocols/bridgedfund"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
@@ -493,6 +494,16 @@ func (ms *MemStore) populateChannelData(obj protocols.Objective) error {
 		o.C = &ch
 
 		return nil
+	case *bridgeddefund.Objective:
+		ch, err := ms.getChannelById(o.C.Id)
+		if err != nil {
+			return fmt.Errorf("error retrieving channel data for objective %s: %w", id, err)
+		}
+
+		o.C = &ch
+
+		return nil
+
 	default:
 		return fmt.Errorf("objective %s did not correctly represent a known Objective type", id)
 	}
@@ -523,6 +534,14 @@ func decodeObjective(id protocols.ObjectiveId, data []byte) (protocols.Objective
 		bfo := bridgedfund.Objective{}
 		err := bfo.UnmarshalJSON(data)
 		return &bfo, err
+	case bridgeddefund.IsBridgedDefundObjective(id):
+		bdfo := bridgeddefund.Objective{}
+		err := bdfo.UnmarshalJSON(data)
+		return &bdfo, err
+	case bridgeddefund.IsBridgedDefundObjective(id):
+		bdfo := bridgeddefund.Objective{}
+		err := bdfo.UnmarshalJSON(data)
+		return &bdfo, err
 	default:
 		return nil, fmt.Errorf("objective id %s does not correspond to a known Objective type", id)
 

--- a/node/node.go
+++ b/node/node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/bridgeddefund"
 	"github.com/statechannels/go-nitro/protocols/bridgedfund"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
@@ -285,6 +286,15 @@ func (n *Node) CreateBridgeChannel(Counterparty types.Address, ChallengeDuration
 // CloseLedgerChannel attempts to close and defund the given directly funded channel.
 func (n *Node) CloseLedgerChannel(channelId types.Destination, isChallenge bool) (protocols.ObjectiveId, error) {
 	objectiveRequest := directdefund.NewObjectiveRequest(channelId, isChallenge)
+
+	// Send the event to the engine
+	n.engine.ObjectiveRequestsFromAPI <- objectiveRequest
+	objectiveRequest.WaitForObjectiveToStart()
+	return objectiveRequest.Id(*n.Address, n.chainId), nil
+}
+
+func (n *Node) CloseBridgeChannel(channelId types.Destination) (protocols.ObjectiveId, error) {
+	objectiveRequest := bridgeddefund.NewObjectiveRequest(channelId)
 
 	// Send the event to the engine
 	n.engine.ObjectiveRequestsFromAPI <- objectiveRequest

--- a/protocols/bridgeddefund/bridgeddefund.go
+++ b/protocols/bridgeddefund/bridgeddefund.go
@@ -1,0 +1,98 @@
+package bridgeddefund
+
+import (
+	"math/big"
+
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+const ObjectivePrefix = "bridgeddefunding-"
+
+// Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data
+type Objective struct {
+	Status protocols.ObjectiveStatus
+	C      *channel.Channel
+}
+
+// TODO: Implement new objective method
+func NewObjective(
+	request ObjectiveRequest,
+) (Objective, error) {
+	ch := channel.Channel{Id: request.ChannelId}
+	return Objective{
+		C: &ch,
+	}, nil
+}
+
+// GetStatus returns the status of the objective.
+func (o *Objective) GetStatus() protocols.ObjectiveStatus {
+	return o.Status
+}
+
+// OwnsChannel returns the channel that the objective is funding.
+func (o *Objective) OwnsChannel() types.Destination {
+	return o.C.Id
+}
+
+func (o *Objective) Related() []protocols.Storable {
+	return []protocols.Storable{o.C}
+}
+
+func (o *Objective) Id() protocols.ObjectiveId {
+	return protocols.ObjectiveId(ObjectivePrefix + o.C.Id.String())
+}
+
+// Crank inspects the extended state and declares a list of Effects to be executed
+// It's like a state machine transition function where the finite / enumerable state is returned (computed from the extended state)
+// rather than being independent of the extended state; and where there is only one type of event ("the crank") with no data on it at all
+func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, error) {
+	// TODO: Implement crank method
+	return o, protocols.SideEffects{}, "", nil
+}
+
+func (o *Objective) Approve() protocols.Objective {
+	// TODO: Implement approve method
+	return o
+}
+
+func (o *Objective) Reject() (protocols.Objective, protocols.SideEffects) {
+	// TODO: Implement reject method
+	return o, protocols.SideEffects{}
+}
+
+// Update receives an ObjectivePayload, applies all applicable data to the BridgedDeFundingObjectiveState,
+// and returns the updated state
+func (o *Objective) Update(p protocols.ObjectivePayload) (protocols.Objective, error) {
+	// TODO: Implement update method
+	return o, nil
+}
+
+// ObjectiveRequest represents a request to create a new bridged defund objective.
+type ObjectiveRequest struct {
+	ChannelId        types.Destination
+	objectiveStarted chan struct{}
+}
+
+// NewObjectiveRequest creates a new ObjectiveRequest.
+func NewObjectiveRequest(channelId types.Destination) ObjectiveRequest {
+	return ObjectiveRequest{
+		ChannelId:        channelId,
+		objectiveStarted: make(chan struct{}),
+	}
+}
+
+func (r ObjectiveRequest) SignalObjectiveStarted() {
+	close(r.objectiveStarted)
+}
+
+// WaitForObjectiveToStart blocks until the objective starts
+func (r ObjectiveRequest) WaitForObjectiveToStart() {
+	<-r.objectiveStarted
+}
+
+// Id returns the objective id for the request.
+func (r ObjectiveRequest) Id(myAddress types.Address, chainId *big.Int) protocols.ObjectiveId {
+	return protocols.ObjectiveId(ObjectivePrefix + r.ChannelId.String())
+}

--- a/protocols/bridgeddefund/bridgeddefund.go
+++ b/protocols/bridgeddefund/bridgeddefund.go
@@ -1,14 +1,21 @@
 package bridgeddefund
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
 
 const ObjectivePrefix = "bridgeddefunding-"
+
+var ErrChannelNotExist error = errors.New("could not find channel")
 
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data
 type Objective struct {
@@ -16,14 +23,35 @@ type Objective struct {
 	C      *channel.Channel
 }
 
-// TODO: Implement new objective method
+// GetConsensusChannel describes functions which return a ConsensusChannel ledger channel for a channel id.
+type GetConsensusChannel func(channelId types.Destination) (ledger *consensus_channel.ConsensusChannel, err error)
+
+// NewObjective initiates an Objective with the supplied channel
 func NewObjective(
 	request ObjectiveRequest,
+	preApprove bool,
+	getConsensusChannel GetConsensusChannel,
 ) (Objective, error) {
-	ch := channel.Channel{Id: request.ChannelId}
-	return Objective{
-		C: &ch,
-	}, nil
+	cc, err := getConsensusChannel(request.ChannelId)
+	if err != nil {
+		return Objective{}, fmt.Errorf("%w %s: %w", ErrChannelNotExist, request.ChannelId, err)
+	}
+
+	c, err := CreateChannelFromConsensusChannel(*cc)
+	if err != nil {
+		return Objective{}, fmt.Errorf("could not create Channel from ConsensusChannel; %w", err)
+	}
+
+	init := Objective{}
+
+	if preApprove {
+		init.Status = protocols.Approved
+	} else {
+		init.Status = protocols.Unapproved
+	}
+	init.C = c.Clone()
+
+	return init, nil
 }
 
 // GetStatus returns the status of the objective.
@@ -53,20 +81,69 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 }
 
 func (o *Objective) Approve() protocols.Objective {
-	// TODO: Implement approve method
-	return o
+	updated := o.clone()
+	// todo: consider case of o.Status == Rejected
+	updated.Status = protocols.Approved
+
+	return &updated
 }
 
 func (o *Objective) Reject() (protocols.Objective, protocols.SideEffects) {
-	// TODO: Implement reject method
-	return o, protocols.SideEffects{}
+	updated := o.clone()
+
+	updated.Status = protocols.Rejected
+	peer := o.C.Participants[1-o.C.MyIndex]
+
+	sideEffects := protocols.SideEffects{MessagesToSend: protocols.CreateRejectionNoticeMessage(o.Id(), peer)}
+	return &updated, sideEffects
 }
 
 // Update receives an ObjectivePayload, applies all applicable data to the BridgedDeFundingObjectiveState,
 // and returns the updated state
 func (o *Objective) Update(p protocols.ObjectivePayload) (protocols.Objective, error) {
-	// TODO: Implement update method
-	return o, nil
+	if o.Id() != p.ObjectiveId {
+		return o, fmt.Errorf("event and objective Ids do not match: %s and %s respectively", string(p.ObjectiveId), string(o.Id()))
+	}
+
+	updated := o.clone()
+	ss, err := getSignedStatePayload(p.PayloadData)
+	if err != nil {
+		return o, fmt.Errorf("could not get signed state payload: %w", err)
+	}
+	updated.C.AddSignedState(ss)
+	return &updated, nil
+}
+
+// clone returns a deep copy of the receiver.
+func (o *Objective) clone() Objective {
+	clone := Objective{}
+	clone.Status = o.Status
+
+	cClone := o.C.Clone()
+	clone.C = cClone
+	return clone
+}
+
+// getSignedStatePayload takes in a serialized signed state payload and returns the deserialized SignedState.
+func getSignedStatePayload(b []byte) (state.SignedState, error) {
+	ss := state.SignedState{}
+	err := json.Unmarshal(b, &ss)
+	if err != nil {
+		return ss, fmt.Errorf("could not unmarshal signed state: %w", err)
+	}
+	return ss, nil
+}
+
+// CreateChannelFromConsensusChannel creates a Channel with (an appropriate latest supported state) from the supplied ConsensusChannel.
+func CreateChannelFromConsensusChannel(cc consensus_channel.ConsensusChannel) (*channel.Channel, error) {
+	c, err := channel.New(cc.ConsensusVars().AsState(cc.SupportedSignedState().State().FixedPart()), uint(cc.MyIndex), channel.Ledger)
+	if err != nil {
+		return &channel.Channel{}, err
+	}
+	c.AddSignedState(cc.SupportedSignedState())
+	c.OnChain.Holdings = cc.OnChainFunding
+
+	return c, nil
 }
 
 // ObjectiveRequest represents a request to create a new bridged defund objective.

--- a/protocols/bridgeddefund/serde.go
+++ b/protocols/bridgeddefund/serde.go
@@ -1,0 +1,15 @@
+package bridgeddefund
+
+import (
+	"encoding/json"
+)
+
+// TODO: Implement marshal json
+func (o Objective) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o)
+}
+
+// TODO: Implement unmarshal json
+func (o *Objective) UnmarshalJSON(data []byte) error {
+	return nil
+}

--- a/protocols/bridgeddefund/serde.go
+++ b/protocols/bridgeddefund/serde.go
@@ -2,14 +2,50 @@ package bridgeddefund
 
 import (
 	"encoding/json"
+
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
 )
 
-// TODO: Implement marshal json
-func (o Objective) MarshalJSON() ([]byte, error) {
-	return json.Marshal(o)
+// jsonObjective replaces the bridgeddefund.Objective's channel pointer with
+// the channel's ID, making jsonObjective suitable for serialization
+type jsonObjective struct {
+	Status protocols.ObjectiveStatus
+	C      types.Destination
 }
 
-// TODO: Implement unmarshal json
+// MarshalJSON returns a JSON representation of the BridgedDefundObjective
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data
+// (other than Id) from the field C is discarded
+func (o Objective) MarshalJSON() ([]byte, error) {
+	jsonDDFO := jsonObjective{
+		o.Status,
+		o.C.Id,
+	}
+
+	return json.Marshal(jsonDDFO)
+}
+
+// UnmarshalJSON populates the calling BridgedDefundObjective with the
+// json-encoded data
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data
+// (other than Id) from the field C is discarded
 func (o *Objective) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	var jsonDDFO jsonObjective
+	err := json.Unmarshal(data, &jsonDDFO)
+	if err != nil {
+		return err
+	}
+
+	o.C = &channel.Channel{}
+
+	o.Status = jsonDDFO.Status
+	o.C.Id = jsonDDFO.C
+
 	return nil
 }


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- A' initiates a bridged defund on L2
- As part of this process, A' updates the state's `isFinal` attribute to true, signs the updated state, and sends it to B'
- Upon receiving the signed state, B' will sign it as well, completing the process for the bridged defund
- TODOs in follow on PRs:
  - Call `mirrorBridgeDefund` in L1 on L2 complete objective