### PR TITLE
Handle mirror bridged defund challenge

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -247,7 +247,7 @@ func (b *Bridge) processCompletedObjectivesFromL1(objId protocols.ObjectiveId) e
 	}
 
 	// Create mirrored ledger channel between node BPrime and APrime
-	l2LedgerChannelResponse, err := b.nodeL2.CreateBridgeChannel(l1ledgerChannelStateClone.State().Participants[0], uint32(5), l2ChannelOutcome)
+	l2LedgerChannelResponse, err := b.nodeL2.CreateBridgeChannel(l1ledgerChannelStateClone.State().Participants[0], l1ledgerChannelStateClone.State().ChallengeDuration, l2ChannelOutcome)
 	if err != nil {
 		return err
 	}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -247,7 +247,7 @@ func (b *Bridge) processCompletedObjectivesFromL1(objId protocols.ObjectiveId) e
 	}
 
 	// Create mirrored ledger channel between node BPrime and APrime
-	l2LedgerChannelResponse, err := b.nodeL2.CreateBridgeChannel(l1ledgerChannelStateClone.State().Participants[0], uint32(10), l2ChannelOutcome)
+	l2LedgerChannelResponse, err := b.nodeL2.CreateBridgeChannel(l1ledgerChannelStateClone.State().Participants[0], uint32(5), l2ChannelOutcome)
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,7 @@ func (b *Bridge) processCompletedObjectivesFromL2(objId protocols.ObjectiveId) e
 		}
 
 		// Initiate mirror bridged defund on L1 using L2 signed state
-		_, err = b.nodeL1.MirrorBridgedDefund(mirrorInfo.L1ChannelId, signedState)
+		_, err = b.nodeL1.MirrorBridgedDefund(mirrorInfo.L1ChannelId, signedState, false)
 		if err != nil {
 			return fmt.Errorf("error in initiating mirror bridged defund: %w", err)
 		}

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -380,11 +380,14 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 		c.OnChain.Outcome = e.Outcome()
 		c.OnChain.FinalizesAt = e.FinalizesAt
 		c.OnChain.IsChallengeInitiatedByMe = e.IsInitiatedByMe
-		ss, err := e.SignedState(c.FixedPart)
-		if err != nil {
-			return nil, err
+		if c.Id == event.ChannelID() {
+			ss, err := e.SignedState(c.FixedPart)
+			if err != nil {
+				return nil, err
+			}
+
+			c.AddSignedState(ss)
 		}
-		c.AddSignedState(ss)
 
 	case chainservice.ChallengeClearedEvent:
 		// On chain, statusOf map is updated with the same values below following a checkpoint transaction in ForceMove contract

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -380,6 +380,8 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 		c.OnChain.Outcome = e.Outcome()
 		c.OnChain.FinalizesAt = e.FinalizesAt
 		c.OnChain.IsChallengeInitiatedByMe = e.IsInitiatedByMe
+
+		// Add a signed state from a chain event to a channel only if the channel ID matches, especially when a challenge is registered on the L2 state, as the channel IDs for L1 and L2 are different
 		if c.Id == event.ChannelID() {
 			ss, err := e.SignedState(c.FixedPart)
 			if err != nil {
@@ -401,10 +403,7 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 	case chainservice.ReclaimedEvent:
 	// TODO: Handle ReclaimedEvent
 	case chainservice.StatusUpdatedEvent:
-		statusUpdatedEvent, ok := event.(chainservice.StatusUpdatedEvent)
-		if ok {
-			c.OnChain.StateHash = statusUpdatedEvent.StateHash
-		}
+		c.OnChain.StateHash = e.StateHash
 	default:
 		return &Channel{}, fmt.Errorf("channel %+v cannot handle event %+v", c, event)
 	}

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -381,7 +381,8 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 		c.OnChain.FinalizesAt = e.FinalizesAt
 		c.OnChain.IsChallengeInitiatedByMe = e.IsInitiatedByMe
 
-		// Add a signed state from a chain event to a channel only if the channel ID matches, especially when a challenge is registered on the L2 state, as the channel IDs for L1 and L2 are different
+		// Add a signed state from a chain event to a channel only if the channel ID matches
+		// If challenge is registered on the L2 state then then channel Ids will be different
 		if c.Id == event.ChannelID() {
 			ss, err := e.SignedState(c.FixedPart)
 			if err != nil {

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -195,7 +195,7 @@ type ChainService interface {
 	GetLastConfirmedBlockNum() uint64
 	// GetLatestBlock returns the latest block
 	GetLatestBlock() Block
-
+	// GetL1ChannelFromL2 returns the L1 ledger channel ID from the L2 ledger channel by making a contract call to the l2ToL1 map of the Nitro Adjudicator contract
 	GetL1ChannelFromL2(l2Channel types.Destination) (types.Destination, error)
 	// Close closes the ChainService
 	Close() error

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -195,6 +195,8 @@ type ChainService interface {
 	GetLastConfirmedBlockNum() uint64
 	// GetLatestBlock returns the latest block
 	GetLatestBlock() Block
+
+	GetL1ChannelFromL2(l2Channel types.Destination) (types.Destination, error)
 	// Close closes the ChainService
 	Close() error
 }

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -195,6 +195,7 @@ type ChainService interface {
 	GetLastConfirmedBlockNum() uint64
 	// GetLatestBlock returns the latest block
 	GetLatestBlock() Block
+	// TODO: Implement method for eth calls
 	// GetL1ChannelFromL2 returns the L1 ledger channel ID from the L2 ledger channel by making a contract call to the l2ToL1 map of the Nitro Adjudicator contract
 	GetL1ChannelFromL2(l2Channel types.Destination) (types.Destination, error)
 	// Close closes the ChainService

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -260,6 +260,14 @@ func (ecs *EthChainService) defaultTxOpts() *bind.TransactOpts {
 	}
 }
 
+// defaultTxOpts returns transaction options suitable for most transaction submissions
+func (ecs *EthChainService) defaultCallOpts() *bind.CallOpts {
+	return &bind.CallOpts{
+		Pending: false,
+		From:    ecs.txSigner.From,
+	}
+}
+
 // SendTransaction sends the transaction and blocks until it has been submitted.
 func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error {
 	switch tx := tx.(type) {
@@ -423,6 +431,10 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 	default:
 		return fmt.Errorf("unexpected transaction type %T", tx)
 	}
+}
+
+func (ecs *EthChainService) GetL1ChannelFromL2(l2Channel types.Destination) (types.Destination, error) {
+	return ecs.na.GetL2ToL1(ecs.defaultCallOpts(), l2Channel)
 }
 
 // dispatchChainEvents takes in a collection of event logs from the chain

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -260,7 +260,7 @@ func (ecs *EthChainService) defaultTxOpts() *bind.TransactOpts {
 	}
 }
 
-// defaultTxOpts returns transaction options suitable for most transaction submissions
+// defaultCallOpts provides options to fine-tune a contract call request
 func (ecs *EthChainService) defaultCallOpts() *bind.CallOpts {
 	return &bind.CallOpts{
 		Pending: false,
@@ -433,6 +433,7 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 	}
 }
 
+// GetL1ChannelFromL2 returns the L1 ledger channel ID from the L2 ledger channel by making a contract call to the l2ToL1 map of the Nitro Adjudicator contract
 func (ecs *EthChainService) GetL1ChannelFromL2(l2Channel types.Destination) (types.Destination, error) {
 	return ecs.na.GetL2ToL1(ecs.defaultCallOpts(), l2Channel)
 }

--- a/node/engine/chainservice/mock_chainservice.go
+++ b/node/engine/chainservice/mock_chainservice.go
@@ -36,6 +36,10 @@ func (mc *MockChainService) GetVirtualPaymentAppAddress() types.Address {
 	return types.Address{}
 }
 
+func (mc *MockChainService) GetL1ChannelFromL2(l2Channel types.Destination) (types.Destination, error) {
+	return types.Destination{}, nil
+}
+
 func (mc *MockChainService) EventFeed() <-chan Event {
 	return mc.eventFeed
 }

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -441,45 +441,42 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 		return EngineEvent{}, err
 	}
 
-	var l2ChallengeRegistered bool
-	c, ok := e.store.GetChannelById(chainEvent.ChannelID())
+	channelId := chainEvent.ChannelID()
+
+	_, isChallengeRegistered := chainEvent.(chainservice.ChallengeRegisteredEvent)
+	if isChallengeRegistered {
+		// Check whether a challenge has been registered for the L2 channel, and then retrieve its L1 channel using an eth call
+		l1ChannelId, err := e.chain.GetL1ChannelFromL2(chainEvent.ChannelID())
+		if err == nil {
+			channelId = l1ChannelId
+		}
+	}
+
+	c, ok := e.store.GetChannelById(channelId)
 	if !ok {
 		// If channel doesn't exist and chain event is ChallengeRegistered then create a new direct defund objective
 		// This doesn't occur for actor who registered the challenge
 		_, isChallengeRegistered := chainEvent.(chainservice.ChallengeRegisteredEvent)
 
 		if isChallengeRegistered {
-
-			l1ChannelId, err := e.chain.GetL1ChannelFromL2(chainEvent.ChannelID())
+			ddfo, err := directdefund.NewObjective(directdefund.NewObjectiveRequest(chainEvent.ChannelID(), false), true, e.store.GetConsensusChannelById, e.store.GetChannelById, e.vm.GetVoucherIfAmountPresent, true)
 			if err != nil {
-				slog.Warn("l1 channel id not found")
+				// Node should not panic if it is unable to find the required consensus channel before creating objective
+				if errors.Is(err, directdefund.ErrChannelNotExist) {
+					return EngineEvent{}, nil
+				}
+
+				return EngineEvent{}, err
 			}
-
-			l1Channel, ok := e.store.GetChannelById(l1ChannelId)
-
-			if ok {
-				c = l1Channel
-				l2ChallengeRegistered = true
-			} else {
-				ddfo, err := directdefund.NewObjective(directdefund.NewObjectiveRequest(chainEvent.ChannelID(), false), true, e.store.GetConsensusChannelById, e.store.GetChannelById, e.vm.GetVoucherIfAmountPresent, true)
-				if err != nil {
-					// Node should not panic if it is unable to find the required consensus channel before creating objective
-					if errors.Is(err, directdefund.ErrChannelNotExist) {
-						return EngineEvent{}, nil
-					}
-
-					return EngineEvent{}, err
-				}
-				// If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
-				err = e.store.DestroyConsensusChannel(chainEvent.ChannelID())
-				if err != nil {
-					return EngineEvent{}, err
-				}
-				c = ddfo.C
-				err = e.store.SetObjective(&ddfo)
-				if err != nil {
-					return EngineEvent{}, err
-				}
+			// If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
+			err = e.store.DestroyConsensusChannel(chainEvent.ChannelID())
+			if err != nil {
+				return EngineEvent{}, err
+			}
+			c = ddfo.C
+			err = e.store.SetObjective(&ddfo)
+			if err != nil {
+				return EngineEvent{}, err
 			}
 		} else {
 			// TODO: Right now the chain service returns chain events for ALL channels even those we aren't involved in
@@ -500,7 +497,7 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 		return EngineEvent{}, err
 	}
 
-	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelID())
+	objective, ok := e.store.GetObjectiveByChannelId(updatedChannel.Id)
 
 	if ok {
 		return e.attemptProgress(objective)
@@ -526,14 +523,6 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 			if ok {
 				return e.attemptProgress(obj)
 			}
-		}
-	}
-
-	if l2ChallengeRegistered {
-		objective, ok := e.store.GetObjectiveByChannelId(updatedChannel.Id)
-
-		if ok {
-			return e.attemptProgress(objective)
 		}
 	}
 
@@ -1114,9 +1103,11 @@ func (e *Engine) processStoreChannels(latestblock chainservice.Block) error {
 				}
 
 			case *mirrorbridgeddefund.Objective:
-				_, err = e.attemptProgress(objective)
-				if err != nil {
-					return err
+				if objective.C.OnChain.IsChallengeInitiatedByMe {
+					_, err = e.attemptProgress(objective)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -1098,20 +1098,22 @@ func (e *Engine) processStoreChannels(latestblock chainservice.Block) error {
 		// Liquidate assets for finalized ledger channels
 		if ch.Type == channel.Ledger && ch.OnChain.ChannelMode == channel.Finalized {
 			obj, ok := e.store.GetObjectiveByChannelId(ch.Id)
-			// TODO: Use switch case to determine the objective
 
-			dDfo, isDdfo := obj.(*directdefund.Objective)
-
-			if ok && isDdfo && dDfo.C.OnChain.IsChallengeInitiatedByMe {
-				_, err = e.attemptProgress(dDfo)
-				if err != nil {
-					return err
-				}
+			if !ok {
+				return fmt.Errorf("Objective not found for liquidating the finalized ledger channel")
 			}
 
-			mBdfo, isMBdfo := obj.(*mirrorbridgeddefund.Objective)
-			if ok && isMBdfo {
-				_, err = e.attemptProgress(mBdfo)
+			switch objective := obj.(type) {
+			case *directdefund.Objective:
+				if objective.C.OnChain.IsChallengeInitiatedByMe {
+					_, err = e.attemptProgress(objective)
+					if err != nil {
+						return err
+					}
+				}
+
+			case *mirrorbridgeddefund.Objective:
+				_, err = e.attemptProgress(objective)
 				if err != nil {
 					return err
 				}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -457,7 +457,10 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 
 			l1Channel, ok := e.store.GetChannelById(l1ChannelId)
 
-			if !ok {
+			if ok {
+				c = l1Channel
+				l2ChallengeRegistered = true
+			} else {
 				ddfo, err := directdefund.NewObjective(directdefund.NewObjectiveRequest(chainEvent.ChannelID(), false), true, e.store.GetConsensusChannelById, e.store.GetChannelById, e.vm.GetVoucherIfAmountPresent, true)
 				if err != nil {
 					// Node should not panic if it is unable to find the required consensus channel before creating objective
@@ -478,10 +481,6 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 					return EngineEvent{}, err
 				}
 			}
-
-			c = l1Channel
-			l2ChallengeRegistered = true
-
 		} else {
 			// TODO: Right now the chain service returns chain events for ALL channels even those we aren't involved in
 			// for now we can ignore channels we aren't involved in

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -441,6 +441,7 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 		return EngineEvent{}, err
 	}
 
+	var L2ChallengeRegistered bool
 	c, ok := e.store.GetChannelById(chainEvent.ChannelID())
 	if !ok {
 		// If channel doesn't exist and chain event is ChallengeRegistered then create a new direct defund objective
@@ -448,25 +449,38 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 		_, isChallengeRegistered := chainEvent.(chainservice.ChallengeRegisteredEvent)
 
 		if isChallengeRegistered {
-			ddfo, err := directdefund.NewObjective(directdefund.NewObjectiveRequest(chainEvent.ChannelID(), false), true, e.store.GetConsensusChannelById, e.store.GetChannelById, e.vm.GetVoucherIfAmountPresent, true)
-			if err != nil {
-				// Node should not panic if it is unable to find the required consensus channel before creating objective
-				if errors.Is(err, directdefund.ErrChannelNotExist) {
-					return EngineEvent{}, nil
-				}
 
-				return EngineEvent{}, err
-			}
-			// If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
-			err = e.store.DestroyConsensusChannel(chainEvent.ChannelID())
+			l1ChannelId, err := e.chain.GetL1ChannelFromL2(chainEvent.ChannelID())
 			if err != nil {
-				return EngineEvent{}, err
+				slog.Warn("l1 channel id not found")
 			}
-			c = ddfo.C
-			err = e.store.SetObjective(&ddfo)
-			if err != nil {
-				return EngineEvent{}, err
+
+			l1Channel, ok := e.store.GetChannelById(l1ChannelId)
+			L2ChallengeRegistered = true
+
+			if !ok {
+				ddfo, err := directdefund.NewObjective(directdefund.NewObjectiveRequest(chainEvent.ChannelID(), false), true, e.store.GetConsensusChannelById, e.store.GetChannelById, e.vm.GetVoucherIfAmountPresent, true)
+				if err != nil {
+					// Node should not panic if it is unable to find the required consensus channel before creating objective
+					if errors.Is(err, directdefund.ErrChannelNotExist) {
+						return EngineEvent{}, nil
+					}
+
+					return EngineEvent{}, err
+				}
+				// If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
+				err = e.store.DestroyConsensusChannel(chainEvent.ChannelID())
+				if err != nil {
+					return EngineEvent{}, err
+				}
+				c = ddfo.C
+				err = e.store.SetObjective(&ddfo)
+				if err != nil {
+					return EngineEvent{}, err
+				}
 			}
+
+			c = l1Channel
 		} else {
 			// TODO: Right now the chain service returns chain events for ALL channels even those we aren't involved in
 			// for now we can ignore channels we aren't involved in
@@ -512,6 +526,14 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 			if ok {
 				return e.attemptProgress(obj)
 			}
+		}
+	}
+
+	if L2ChallengeRegistered {
+		objective, ok := e.store.GetObjectiveByChannelId(updatedChannel.Id)
+
+		if ok {
+			return e.attemptProgress(objective)
 		}
 	}
 
@@ -1076,10 +1098,20 @@ func (e *Engine) processStoreChannels(latestblock chainservice.Block) error {
 		// Liquidate assets for finalized ledger channels
 		if ch.Type == channel.Ledger && ch.OnChain.ChannelMode == channel.Finalized {
 			obj, ok := e.store.GetObjectiveByChannelId(ch.Id)
+			// TODO: Use switch case to determine the objective
+
 			dDfo, isDdfo := obj.(*directdefund.Objective)
 
 			if ok && isDdfo && dDfo.C.OnChain.IsChallengeInitiatedByMe {
 				_, err = e.attemptProgress(dDfo)
+				if err != nil {
+					return err
+				}
+			}
+
+			mBdfo, isMBdfo := obj.(*mirrorbridgeddefund.Objective)
+			if ok && isMBdfo {
+				_, err = e.attemptProgress(mBdfo)
 				if err != nil {
 					return err
 				}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -445,9 +445,13 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 
 	_, isChallengeRegistered := chainEvent.(chainservice.ChallengeRegisteredEvent)
 	if isChallengeRegistered {
-		// Check whether a challenge has been registered for the L2 channel, and then retrieve its L1 channel using an eth call
+		// Check whether a challenge has been registered for the L2 channel, and then retrieve its L1 channel using an eth call to NitroAdjudicator contract
 		l1ChannelId, err := e.chain.GetL1ChannelFromL2(chainEvent.ChannelID())
-		if err == nil {
+		if err != nil {
+			return EngineEvent{}, err
+		}
+
+		if !l1ChannelId.IsZero() {
 			channelId = l1ChannelId
 		}
 	}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -441,7 +441,7 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 		return EngineEvent{}, err
 	}
 
-	var L2ChallengeRegistered bool
+	var l2ChallengeRegistered bool
 	c, ok := e.store.GetChannelById(chainEvent.ChannelID())
 	if !ok {
 		// If channel doesn't exist and chain event is ChallengeRegistered then create a new direct defund objective
@@ -456,7 +456,6 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 			}
 
 			l1Channel, ok := e.store.GetChannelById(l1ChannelId)
-			L2ChallengeRegistered = true
 
 			if !ok {
 				ddfo, err := directdefund.NewObjective(directdefund.NewObjectiveRequest(chainEvent.ChannelID(), false), true, e.store.GetConsensusChannelById, e.store.GetChannelById, e.vm.GetVoucherIfAmountPresent, true)
@@ -481,6 +480,8 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 			}
 
 			c = l1Channel
+			l2ChallengeRegistered = true
+
 		} else {
 			// TODO: Right now the chain service returns chain events for ALL channels even those we aren't involved in
 			// for now we can ignore channels we aren't involved in
@@ -529,7 +530,7 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 		}
 	}
 
-	if L2ChallengeRegistered {
+	if l2ChallengeRegistered {
 		objective, ok := e.store.GetObjectiveByChannelId(updatedChannel.Id)
 
 		if ok {
@@ -1100,7 +1101,8 @@ func (e *Engine) processStoreChannels(latestblock chainservice.Block) error {
 			obj, ok := e.store.GetObjectiveByChannelId(ch.Id)
 
 			if !ok {
-				return fmt.Errorf("Objective not found for liquidating the finalized ledger channel")
+				slog.Debug("Objective not found for liquidating the finalized ledger channel", "ledger channel", ch.Id)
+				return nil
 			}
 
 			switch objective := obj.(type) {

--- a/node/node.go
+++ b/node/node.go
@@ -304,8 +304,8 @@ func (n *Node) CloseBridgeChannel(channelId types.Destination) (protocols.Object
 	return objectiveRequest.Id(*n.Address, n.chainId), nil
 }
 
-func (n *Node) MirrorBridgedDefund(l1ChannelId types.Destination, l2SignedState state.SignedState) (protocols.ObjectiveId, error) {
-	objectiveRequest := mirrorbridgeddefund.NewObjectiveRequest(l1ChannelId, l2SignedState)
+func (n *Node) MirrorBridgedDefund(l1ChannelId types.Destination, l2SignedState state.SignedState, isChallenge bool) (protocols.ObjectiveId, error) {
+	objectiveRequest := mirrorbridgeddefund.NewObjectiveRequest(l1ChannelId, l2SignedState, isChallenge)
 
 	// Send the event to the engine
 	n.engine.ObjectiveRequestsFromAPI <- objectiveRequest

--- a/node/query/query.go
+++ b/node/query/query.go
@@ -58,11 +58,20 @@ func getPaymentChannelBalance(participants []types.Address, outcome outcome.Exit
 
 // getLatestSupportedOrPreFund returns the latest supported state of the channel
 // or the prefund state if no supported state exists
-func getLatestSupportedOrPreFund(channel *channel.Channel) (state.State, error) {
-	if channel.HasSupportedState() {
-		return channel.LatestSupportedState()
+func getLatestSupportedOrPreFund(ledgerChannel *channel.Channel) (state.State, error) {
+	// Returns the latest signed state if assets are liquidated due to challenge transaction
+	if ledgerChannel.OnChain.ChannelMode == channel.Finalized {
+		ss, err := ledgerChannel.LatestSignedState()
+		if err != nil {
+			return state.State{}, err
+		}
+		return ss.State(), nil
 	}
-	return channel.PreFundState(), nil
+
+	if ledgerChannel.HasSupportedState() {
+		return ledgerChannel.LatestSupportedState()
+	}
+	return ledgerChannel.PreFundState(), nil
 }
 
 // getLedgerBalanceFromState returns the balance of the ledger channel from the given state

--- a/node/query/query.go
+++ b/node/query/query.go
@@ -59,15 +59,6 @@ func getPaymentChannelBalance(participants []types.Address, outcome outcome.Exit
 // getLatestSupportedOrPreFund returns the latest supported state of the channel
 // or the prefund state if no supported state exists
 func getLatestSupportedOrPreFund(ledgerChannel *channel.Channel) (state.State, error) {
-	// Returns the latest signed state if assets are liquidated due to challenge transaction
-	if ledgerChannel.OnChain.ChannelMode == channel.Finalized {
-		ss, err := ledgerChannel.LatestSignedState()
-		if err != nil {
-			return state.State{}, err
-		}
-		return ss.State(), nil
-	}
-
 	if ledgerChannel.HasSupportedState() {
 		return ledgerChannel.LatestSupportedState()
 	}

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -507,6 +507,8 @@ func TestBridgedFundWithChallenge(t *testing.T) {
 			}
 		}
 
+		checkLedgerChannel(t, l1LedgerChannelId, ledgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, payAmount, types.Address{}), query.Complete, nodeA)
+
 		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
 		balanceBridge, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())
 		t.Logf("Balance of node A %v \nBalance of Bridge %v", balanceNodeA, balanceBridge)

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -370,86 +370,150 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 	})
 }
 
-func TestExitL2WithLedgerChannelStateUnilaterally(t *testing.T) {
-	utils, cleanupUtils := initializeUtils(t, false)
-	defer cleanupUtils()
-
-	tcL1, tcL2 := utils.tcL1, utils.tcL2
-	nodeA, nodeB := utils.nodeA, utils.nodeB
-	nodeAPrime, nodeBPrime := utils.nodeAPrime, utils.nodeBPrime
-	chainServiceA, chainServiceB := utils.chainServiceA, utils.chainServiceB
-	testChainService := utils.testChainService
-	storeA := utils.storeA
-	storeAPrime, storeBPrime := utils.storeAPrime, utils.storeBPrime
-	infraL1, infraL2 := utils.infraL1, utils.infraL2
-
-	infraL2.anvilChain.ContractAddresses.CaAddress = infraL1.anvilChain.ContractAddresses.CaAddress
-	infraL2.anvilChain.ContractAddresses.VpaAddress = infraL1.anvilChain.ContractAddresses.VpaAddress
-
-	// Create ledger channel on L1 and mirror it on L2
-	l1ChannelId, mirroredLedgerChannelId := createL1L2Channels(t, nodeA, nodeB, nodeAPrime, nodeBPrime, storeA, tcL1, tcL2, chainServiceB)
-
-	// Create virtual channel on mirrored ledger channel and make payments
-	virtualChannel := createL2VirtualChannel(t, nodeAPrime, nodeBPrime, storeBPrime, tcL2)
-
-	// Bridge pays APrime
-	err := nodeBPrime.Pay(virtualChannel.Id, big.NewInt(payAmount))
-	if err != nil {
-		t.Fatal(err)
+func TestBridgedFundWithChallenge(t *testing.T) {
+	tcL1 := TestCase{
+		Chain:             AnvilChainL1,
+		MessageService:    P2PMessageService,
+		MessageDelay:      0,
+		LogName:           "Bridge_test",
+		ChallengeDuration: 5,
+		Participants: []TestParticipant{
+			{StoreType: MemStore, Actor: testactors.Alice},
+			{StoreType: MemStore, Actor: testactors.Bob},
+		},
+		deployerIndex: 1,
 	}
 
-	// Wait for APrime to recieve voucher
-	nodeAPrimeVoucher := <-nodeAPrime.ReceivedVouchers()
-	t.Logf("Voucher recieved %+v", nodeAPrimeVoucher)
+	tcL2 := TestCase{
+		Chain:             AnvilChainL2,
+		MessageService:    P2PMessageService,
+		MessageDelay:      0,
+		LogName:           "Bridge_test",
+		ChallengeDuration: 5,
+		Participants: []TestParticipant{
+			{StoreType: MemStore, Actor: testactors.BobPrime},
+			{StoreType: MemStore, Actor: testactors.AlicePrime},
+		},
+		ChainPort:     "8546",
+		deployerIndex: 0,
+	}
 
-	// Virtual defund
-	virtualDefundResponse, _ := nodeBPrime.ClosePaymentChannel(virtualChannel.Id)
-	waitForObjectives(t, nodeBPrime, nodeAPrime, []node.Node{}, []protocols.ObjectiveId{virtualDefundResponse})
+	dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
+	defer cleanup()
 
-	t.Run("Exit to L1 using L2 ledger channel state unilaterally", func(t *testing.T) {
-		l2SignedState := getLatestSignedState(storeAPrime, mirroredLedgerChannelId)
+	infraL1 := setupSharedInfra(tcL1)
+	defer infraL1.Close(t)
 
-		// Close bridge nodes
-		nodeB.Close()
-		nodeBPrime.Close()
+	infraL2 := setupSharedInfra(tcL2)
+	defer infraL2.Close(t)
 
-		// Node A calls `challenge` contract method with L2 ledger channel state
-		challengerSig, _ := NitroAdjudicator.SignChallengeMessage(l2SignedState.State(), tcL1.Participants[0].PrivateKey)
-		challengeTx := protocols.NewChallengeTransaction(l1ChannelId, l2SignedState, []state.SignedState{}, challengerSig)
-		err := chainServiceA.SendTransaction(challengeTx)
+	bridgeConfig := bridge.BridgeConfig{
+		L1ChainUrl:        infraL1.anvilChain.ChainUrl,
+		L2ChainUrl:        infraL2.anvilChain.ChainUrl,
+		L1ChainStartBlock: 0,
+		L2ChainStartBlock: 0,
+		ChainPK:           infraL1.anvilChain.ChainPks[tcL1.Participants[1].ChainAccountIndex],
+		StateChannelPK:    common.Bytes2Hex(tcL1.Participants[1].PrivateKey),
+		NaAddress:         infraL1.anvilChain.ContractAddresses.NaAddress.String(),
+		VpaAddress:        infraL1.anvilChain.ContractAddresses.VpaAddress.String(),
+		CaAddress:         infraL1.anvilChain.ContractAddresses.CaAddress.String(),
+		BridgeAddress:     infraL2.anvilChain.ContractAddresses.BridgeAddress.String(),
+		DurableStoreDir:   dataFolder,
+		BridgePublicIp:    DEFAULT_PUBLIC_IP,
+		NodeL1MsgPort:     int(tcL1.Participants[1].Port),
+		NodeL2MsgPort:     int(tcL2.Participants[0].Port),
+	}
+
+	bridge := bridge.New()
+	_, _, bridgeMultiaddressL1, bridgeMultiaddressL2, err := bridge.Start(bridgeConfig)
+	if err != nil {
+		t.Log("error in starting bridge", err)
+	}
+	defer bridge.Close()
+	bridgeAddress := bridge.GetBridgeAddress()
+
+	nodeA, _, _, _, _ := setupIntegrationNode(tcL1, tcL1.Participants[0], infraL1, []string{bridgeMultiaddressL1}, dataFolder)
+	defer nodeA.Close()
+
+	nodeAPrime, _, _, storeAPrime, _ := setupIntegrationNode(tcL2, tcL2.Participants[1], infraL2, []string{bridgeMultiaddressL2}, dataFolder)
+	defer nodeAPrime.Close()
+
+	var l1LedgerChannelId types.Destination
+	var l2LedgerChannelId types.Destination
+
+	t.Run("Create ledger channel on L1 and mirror it on L2", func(t *testing.T) {
+		// Alice create ledger channel with bridge
+		outcome := CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, types.Address{})
+		l1LedgerChannelResponse, err := nodeA.CreateLedgerChannel(bridgeAddress, uint32(tcL1.ChallengeDuration), outcome)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
+		}
+		t.Log("Waiting for direct-fund objective to complete...")
+		l1LedgerChannelId = l1LedgerChannelResponse.ChannelId
+		<-nodeA.ObjectiveCompleteChan(l1LedgerChannelResponse.Id)
+		t.Log("L1 channel created", l1LedgerChannelResponse.Id)
+
+		// Wait for mirror channel to be created
+		completedMirrorChannel := <-bridge.CompletedMirrorChannels()
+		l2LedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
+		testhelpers.Assert(t, completedMirrorChannel == l2LedgerChannelId, "Expects mirror channel id to be %v", l2LedgerChannelId)
+		checkLedgerChannel(t, l1LedgerChannelResponse.ChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, types.Address{}), query.Open, nodeA)
+		checkLedgerChannel(t, l2LedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeAPrime.Address, 0, ledgerChannelDeposit, types.Address{}), query.Open, nodeAPrime)
+	})
+
+	t.Run("Create virtual channel on mirrored ledger channel and make payments", func(t *testing.T) {
+		// Create virtual channel on mirrored ledger channel on L2
+		virtualOutcome := initialPaymentOutcome(*nodeAPrime.Address, bridgeAddress, types.Address{})
+		virtualResponse, _ := nodeAPrime.CreatePaymentChannel([]types.Address{}, bridgeAddress, uint32(tcL2.ChallengeDuration), virtualOutcome)
+		<-nodeAPrime.ObjectiveCompleteChan(virtualResponse.Id)
+		checkPaymentChannel(t, virtualResponse.ChannelId, virtualOutcome, query.Open, nodeAPrime)
+
+		// APrime pays BPrime
+		nodeAPrime.Pay(virtualResponse.ChannelId, big.NewInt(payAmount))
+
+		// Virtual defund
+		virtualDefundResponse, _ := nodeAPrime.ClosePaymentChannel(virtualResponse.ChannelId)
+		<-nodeAPrime.ObjectiveCompleteChan(virtualDefundResponse)
+
+		ledgerChannelInfo, _ := nodeAPrime.GetLedgerChannel(l2LedgerChannelId)
+		balanceNodeBPrime := ledgerChannelInfo.Balance.TheirBalance.ToInt()
+		balanceNodeAPrime := ledgerChannelInfo.Balance.MyBalance.ToInt()
+		t.Log("Balance of node BPrime", balanceNodeBPrime, "\nBalance of node APrime", balanceNodeAPrime)
+
+		// APrime's balance is determined by subtracting amount paid from it's ledger deposit, while BPrime's balance is calculated by adding the amount received
+		testhelpers.Assert(t, balanceNodeBPrime.Cmp(big.NewInt(payAmount)) == 0, "Balance of node BPrime (%v) should be equal to (%v)", balanceNodeBPrime, ledgerChannelDeposit+payAmount)
+		testhelpers.Assert(t, balanceNodeAPrime.Cmp(big.NewInt(ledgerChannelDeposit-payAmount)) == 0, "Balance of node APrime (%v) should be equal to (%v)", balanceNodeAPrime, ledgerChannelDeposit-payAmount)
+	})
+
+	t.Run("Unilaterally exit to L1 using updated L2 ledger channel state after making payments", func(t *testing.T) {
+		cc, err := storeAPrime.GetConsensusChannelById(l2LedgerChannelId)
+		if err != nil {
+			t.Fatal("required L2 ledger channel not found: %w", err)
 		}
 
-		event := waitForEvent(t, testChainService.EventFeed(), chainservice.ChallengeRegisteredEvent{})
-		t.Log("Challenge registed event received", event)
-		challengeRegisteredEvent, ok := event.(chainservice.ChallengeRegisteredEvent)
-		testhelpers.Assert(t, ok, "Expected challenge registered event")
+		l2SignedState := cc.SupportedSignedState()
 
-		time.Sleep(time.Duration(tcL1.ChallengeDuration) * time.Second)
-		latestBlock, _ := infraL1.anvilChain.GetLatestBlock()
-		testhelpers.Assert(t, challengeRegisteredEvent.FinalizesAt.Uint64() <= latestBlock.Header().Time, "Expected channel to be finalized")
-
-		l2ChannelSignedState := getLatestSignedState(storeAPrime, mirroredLedgerChannelId)
-
-		mirrorTransferAllTx := protocols.NewMirrorTransferAllTransaction(l1ChannelId, l2ChannelSignedState)
-		err = chainServiceA.SendTransaction(mirrorTransferAllTx)
+		ch := nodeA.CompletedObjectives()
+		// Alice unilaterally exits from L1 using L2 signed state
+		_, err = nodeA.MirrorBridgedDefund(l1LedgerChannelId, l2SignedState, true)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
-		// Listen for allocation updated event
-		event = waitForEvent(t, testChainService.EventFeed(), chainservice.AllocationUpdatedEvent{})
-		_, ok = event.(chainservice.AllocationUpdatedEvent)
-		testhelpers.Assert(t, ok, "Expected allocation updated event")
+		// Wait for mirror bridged defund to complete
+		for val := range ch {
+			if val == protocols.ObjectiveId(mirrorbridgeddefund.ObjectivePrefix+l1LedgerChannelId.String()) {
+				break
+			}
+		}
 
 		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
-		balanceNodeB, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())
-		t.Log("Balance of node A", balanceNodeA, "\nBalance of node B", balanceNodeB)
+		balanceBridge, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())
+		t.Logf("Balance of node A %v \nBalance of Bridge %v", balanceNodeA, balanceBridge)
 
-		// Node A's and node B's balance should be equal to ledgerChannelDeposit since no payments happened
-		testhelpers.Assert(t, balanceNodeA.Cmp(big.NewInt(ledgerChannelDeposit+payAmount)) == 0, "Balance of node A (%v) should be equal to (%v)", balanceNodeA, ledgerChannelDeposit+payAmount)
-		testhelpers.Assert(t, balanceNodeB.Cmp(big.NewInt(ledgerChannelDeposit-payAmount)) == 0, "Balance of node B (%v) should be equal to (%v)", balanceNodeB, ledgerChannelDeposit-payAmount)
+		// NodeA's balance is determined by subtracting amount paid from it's ledger deposit, while Bridge's balance is calculated by adding the amount received
+		testhelpers.Assert(t, balanceNodeA.Cmp(big.NewInt(ledgerChannelDeposit-payAmount)) == 0, "Balance of node A (%v) should be equal to (%v)", balanceNodeA, ledgerChannelDeposit-payAmount)
+		testhelpers.Assert(t, balanceBridge.Cmp(big.NewInt(payAmount)) == 0, "Balance of Bridge (%v) should be equal to (%v)", balanceBridge, payAmount)
 	})
 }
 

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -507,7 +507,7 @@ func TestBridgedFundWithChallenge(t *testing.T) {
 			}
 		}
 
-		checkLedgerChannel(t, l1LedgerChannelId, ledgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, payAmount, types.Address{}), query.Complete, nodeA)
+		checkLedgerChannel(t, l1LedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, payAmount, types.Address{}), query.Complete, nodeA)
 
 		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
 		balanceBridge, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())

--- a/packages/nitro-protocol/scripts/postdeploy.js
+++ b/packages/nitro-protocol/scripts/postdeploy.js
@@ -33,7 +33,6 @@ function createEnvForContractAddresses(contractAddresses) {
             });
             var outputFilePath = path.resolve(envFilePath);
             writeFileSync(outputFilePath, envToWrite);
-            console.log('Contracts deployed and address written to', outputFilePath);
         };
         for (var _i = 0, networkArray_1 = networkArray; _i < networkArray_1.length; _i++) {
             var network = networkArray_1[_i];

--- a/packages/nitro-protocol/scripts/postdeploy.ts
+++ b/packages/nitro-protocol/scripts/postdeploy.ts
@@ -43,12 +43,12 @@ function createEnvForContractAddresses(contractAddresses: ContractDetails) {
         if (CONTRACT_ENV_MAP.hasOwnProperty(contractName)) {
           envName = CONTRACT_ENV_MAP[contractName];
         } 
+
         envToWrite += `export ${envName}=${envValue}\n`;
       });
 
       const outputFilePath = path.resolve(envFilePath);
       writeFileSync(outputFilePath, envToWrite);
-      console.log('Contracts deployed and address written to', outputFilePath);
     }
   } 
 }

--- a/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
+++ b/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
@@ -35,13 +35,12 @@ const (
 
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data
 type Objective struct {
-	Status                     protocols.ObjectiveStatus
-	C                          *channel.Channel
-	L2SignedState              state.SignedState
-	MirrorTransactionSubmitted bool
-
-	IsChallenge                   bool
-	ChallengeTransactionSubmitted bool
+	Status                        protocols.ObjectiveStatus
+	C                             *channel.Channel
+	l2SignedState                 state.SignedState
+	mirrorTransactionSubmitted    bool
+	isChallenge                   bool
+	challengeTransactionSubmitted bool
 }
 
 // GetConsensusChannel describes functions which return a ConsensusChannel ledger channel for a channel id.
@@ -73,8 +72,8 @@ func NewObjective(
 	}
 	init.C = c.Clone()
 
-	init.L2SignedState = request.l2SignedState
-	init.IsChallenge = request.isChallenge
+	init.l2SignedState = request.l2SignedState
+	init.isChallenge = request.isChallenge
 	return init, nil
 }
 
@@ -210,10 +209,10 @@ func (o *Objective) clone() Objective {
 	clone.Status = o.Status
 
 	clone.C = o.C.Clone()
-	clone.L2SignedState = o.L2SignedState
-	clone.MirrorTransactionSubmitted = o.MirrorTransactionSubmitted
-	clone.IsChallenge = o.IsChallenge
-	clone.ChallengeTransactionSubmitted = o.ChallengeTransactionSubmitted
+	clone.l2SignedState = o.l2SignedState
+	clone.mirrorTransactionSubmitted = o.mirrorTransactionSubmitted
+	clone.isChallenge = o.isChallenge
+	clone.challengeTransactionSubmitted = o.challengeTransactionSubmitted
 
 	return clone
 }
@@ -236,7 +235,7 @@ func (o *Objective) CreateL1StateBasedOnL2() (state.State, error) {
 		return state.State{}, fmt.Errorf("could not retrieve latest signed state %w", err)
 	}
 
-	l1VariablePartBasedOnL2 := o.L2SignedState.State().VariablePart()
+	l1VariablePartBasedOnL2 := o.l2SignedState.State().VariablePart()
 
 	// Swap the L2 outcome: since Alice creates a ledger channel in L1, the 0th position in L1's state allocations corresponds to Alice. Similarly, since Bridge Prime creates a ledger channel in L2, the 0th position in L2's state allocations corresponds to Bridge Prime.
 	l1OutcomeBasedOnL2 := l1VariablePartBasedOnL2.Outcome.Clone()

--- a/protocols/mirrorbridgeddefund/serde.go
+++ b/protocols/mirrorbridgeddefund/serde.go
@@ -27,10 +27,10 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 	jsonDDFO := jsonObjective{
 		o.Status,
 		o.C.Id,
-		o.MirrorTransactionSubmitted,
-		o.L2SignedState,
-		o.IsChallenge,
-		o.ChallengeTransactionSubmitted,
+		o.mirrorTransactionSubmitted,
+		o.l2SignedState,
+		o.isChallenge,
+		o.challengeTransactionSubmitted,
 	}
 
 	return json.Marshal(jsonDDFO)
@@ -55,10 +55,10 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 
 	o.Status = jsonDDFO.Status
 	o.C.Id = jsonDDFO.C
-	o.MirrorTransactionSubmitted = jsonDDFO.MirrorTransactionSubmitted
-	o.L2SignedState = jsonDDFO.L2SignedState
-	o.IsChallenge = jsonDDFO.IsChallenge
-	o.ChallengeTransactionSubmitted = jsonDDFO.ChallengeTransactionSubmitted
+	o.mirrorTransactionSubmitted = jsonDDFO.MirrorTransactionSubmitted
+	o.l2SignedState = jsonDDFO.L2SignedState
+	o.isChallenge = jsonDDFO.IsChallenge
+	o.challengeTransactionSubmitted = jsonDDFO.ChallengeTransactionSubmitted
 
 	return nil
 }

--- a/protocols/mirrorbridgeddefund/serde.go
+++ b/protocols/mirrorbridgeddefund/serde.go
@@ -12,10 +12,12 @@ import (
 // jsonObjective replaces the mirrorbridgeddefund.Objective's channel pointer with
 // the channel's ID, making jsonObjective suitable for serialization
 type jsonObjective struct {
-	Status                     protocols.ObjectiveStatus
-	C                          types.Destination
-	MirrorTransactionSubmitted bool
-	L2SignedState              state.SignedState
+	Status                        protocols.ObjectiveStatus
+	C                             types.Destination
+	MirrorTransactionSubmitted    bool
+	L2SignedState                 state.SignedState
+	IsChallenge                   bool
+	ChallengeTransactionSubmitted bool
 }
 
 // MarshalJSON returns a JSON representation of the MirrorBridgedDefundObjective
@@ -27,6 +29,8 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 		o.C.Id,
 		o.MirrorTransactionSubmitted,
 		o.L2SignedState,
+		o.IsChallenge,
+		o.ChallengeTransactionSubmitted,
 	}
 
 	return json.Marshal(jsonDDFO)
@@ -53,6 +57,8 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.C.Id = jsonDDFO.C
 	o.MirrorTransactionSubmitted = jsonDDFO.MirrorTransactionSubmitted
 	o.L2SignedState = jsonDDFO.L2SignedState
+	o.IsChallenge = jsonDDFO.IsChallenge
+	o.ChallengeTransactionSubmitted = jsonDDFO.ChallengeTransactionSubmitted
 
 	return nil
 }

--- a/protocols/mirrorbridgeddefund/serde.go
+++ b/protocols/mirrorbridgeddefund/serde.go
@@ -27,10 +27,10 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 	jsonDDFO := jsonObjective{
 		o.Status,
 		o.C.Id,
-		o.mirrorTransactionSubmitted,
-		o.l2SignedState,
-		o.isChallenge,
-		o.challengeTransactionSubmitted,
+		o.MirrorTransactionSubmitted,
+		o.L2SignedState,
+		o.IsChallenge,
+		o.ChallengeTransactionSubmitted,
 	}
 
 	return json.Marshal(jsonDDFO)
@@ -55,10 +55,10 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 
 	o.Status = jsonDDFO.Status
 	o.C.Id = jsonDDFO.C
-	o.mirrorTransactionSubmitted = jsonDDFO.MirrorTransactionSubmitted
-	o.l2SignedState = jsonDDFO.L2SignedState
-	o.isChallenge = jsonDDFO.IsChallenge
-	o.challengeTransactionSubmitted = jsonDDFO.ChallengeTransactionSubmitted
+	o.MirrorTransactionSubmitted = jsonDDFO.MirrorTransactionSubmitted
+	o.L2SignedState = jsonDDFO.L2SignedState
+	o.IsChallenge = jsonDDFO.IsChallenge
+	o.ChallengeTransactionSubmitted = jsonDDFO.ChallengeTransactionSubmitted
 
 	return nil
 }


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Nodes are able to unilaterally exit L1 using L2 ledger channel state
- Add test case for mirror bridged defund objective with challenge