### PR TITLE
Use confirmed blocks for processing store channels

### DIFF
--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -194,9 +194,7 @@ type ChainService interface {
 	GetChainId() (*big.Int, error)
 	// GetLastConfirmedBlockNum returns the highest blockNum that satisfies the chainservice's REQUIRED_BLOCK_CONFIRMATIONS
 	GetLastConfirmedBlockNum() uint64
-	// GetLatestBlock returns the latest block
-	GetLatestBlock() Block
-
+	// GetBlockByNumber returns the block for given block number
 	GetBlockByNumber(blockNum *big.Int) (*ethTypes.Block, error)
 	// Close closes the ChainService
 	Close() error

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
@@ -195,6 +196,8 @@ type ChainService interface {
 	GetLastConfirmedBlockNum() uint64
 	// GetLatestBlock returns the latest block
 	GetLatestBlock() Block
+
+	GetBlockByNumber(blockNum *big.Int) (*ethTypes.Block, error)
 	// Close closes the ChainService
 	Close() error
 }

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -785,12 +785,6 @@ func (ecs *EthChainService) GetLastConfirmedBlockNum() uint64 {
 	return confirmedBlockNum
 }
 
-func (ecs *EthChainService) GetLatestBlock() Block {
-	ecs.eventTracker.mu.Lock()
-	defer ecs.eventTracker.mu.Unlock()
-	return ecs.eventTracker.latestBlock
-}
-
 func (ecs *EthChainService) GetBlockByNumber(blockNum *big.Int) (*ethTypes.Block, error) {
 	block, err := ecs.chain.BlockByNumber(context.Background(), blockNum)
 	if err != nil {

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -166,7 +166,13 @@ func newEthChainService(chain ethChain, startBlockNum uint64, na *NitroAdjudicat
 		return nil, err
 	}
 
-	ecs.newBlockChan = newBlockChan
+	newBlockSubChan := make(chan *ethTypes.Header)
+	_, err = ecs.chain.SubscribeNewHead(ecs.ctx, newBlockSubChan)
+	if err != nil {
+		return nil, err
+	}
+
+	ecs.newBlockChan = newBlockSubChan
 
 	// Prevent go routines from processing events before checkForMissedEvents completes
 	ecs.eventTracker.mu.Lock()

--- a/node/engine/chainservice/l2_chainservice.go
+++ b/node/engine/chainservice/l2_chainservice.go
@@ -94,14 +94,6 @@ func newL2ChainService(chain ethChain, startBlockNum uint64, bridge *Bridge.Brid
 		return nil, err
 	}
 
-	newBlockSubChan := make(chan *ethTypes.Header)
-	_, err = l2cs.chain.SubscribeNewHead(ecs.ctx, newBlockSubChan)
-	if err != nil {
-		return nil, err
-	}
-
-	l2cs.newBlockChan = newBlockSubChan
-
 	// Prevent go routines from processing events before checkForMissedEvents completes
 	l2cs.eventTracker.mu.Lock()
 	defer l2cs.eventTracker.mu.Unlock()

--- a/node/engine/chainservice/l2_chainservice.go
+++ b/node/engine/chainservice/l2_chainservice.go
@@ -94,7 +94,13 @@ func newL2ChainService(chain ethChain, startBlockNum uint64, bridge *Bridge.Brid
 		return nil, err
 	}
 
-	l2cs.newBlockChan = newBlockChan
+	newBlockSubChan := make(chan *ethTypes.Header)
+	_, err = l2cs.chain.SubscribeNewHead(ecs.ctx, newBlockSubChan)
+	if err != nil {
+		return nil, err
+	}
+
+	l2cs.newBlockChan = newBlockSubChan
 
 	// Prevent go routines from processing events before checkForMissedEvents completes
 	l2cs.eventTracker.mu.Lock()

--- a/node/engine/chainservice/mock_chainservice.go
+++ b/node/engine/chainservice/mock_chainservice.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -60,6 +61,10 @@ func (mc *MockChainService) GetLatestBlock() Block {
 	return Block{
 		BlockNum: blockNum,
 	}
+}
+
+func (mc *MockChainService) GetBlockByNumber(blockNum *big.Int) (*ethTypes.Block, error) {
+	return &ethTypes.Block{}, nil
 }
 
 func (mc *MockChainService) Close() error {

--- a/node/engine/chainservice/mock_chainservice.go
+++ b/node/engine/chainservice/mock_chainservice.go
@@ -53,16 +53,6 @@ func (mc *MockChainService) GetLastConfirmedBlockNum() uint64 {
 	return blockNum
 }
 
-func (mc *MockChainService) GetLatestBlock() Block {
-	mc.chain.blockNumMu.Lock()
-	blockNum := mc.chain.BlockNum
-	mc.chain.blockNumMu.Unlock()
-
-	return Block{
-		BlockNum: blockNum,
-	}
-}
-
 func (mc *MockChainService) GetBlockByNumber(blockNum *big.Int) (*ethTypes.Block, error) {
 	return &ethTypes.Block{}, nil
 }

--- a/node/engine/chainservice/simulated_backend_chainservice.go
+++ b/node/engine/chainservice/simulated_backend_chainservice.go
@@ -94,9 +94,12 @@ func (sbcs *SimulatedBackendChainService) SendTransaction(tx protocols.ChainTran
 		return err
 	}
 	sbcs.sim.Commit()
-	// Mint two additional blocks to satisfy REQUIRED_BLOCK_CONFIRMATIONS.
-	sbcs.sim.Commit()
-	sbcs.sim.Commit()
+
+	// Mint additional blocks to satisfy REQUIRED_BLOCK_CONFIRMATIONS.
+	for i := 0; i < REQUIRED_BLOCK_CONFIRMATIONS; i++ {
+		sbcs.sim.Commit()
+	}
+
 	return nil
 }
 

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -215,13 +215,12 @@ func (e *Engine) run(ctx context.Context) {
 			var block *ethTypes.Block
 
 			block, err = e.chain.GetBlockByNumber(big.NewInt(int64(blockNum)))
+			e.checkError(err)
 
 			chainServiceBlock := chainservice.Block{
 				BlockNum:  block.NumberU64(),
 				Timestamp: block.Time(),
 			}
-
-			e.checkError(err)
 
 			err = e.processStoreChannels(chainServiceBlock)
 		case <-ctx.Done():

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
@@ -210,8 +211,19 @@ func (e *Engine) run(ctx context.Context) {
 			blockNum := e.chain.GetLastConfirmedBlockNum()
 			err = e.store.SetLastBlockNumSeen(blockNum)
 			e.checkError(err)
-			block := e.chain.GetLatestBlock()
-			err = e.processStoreChannels(block)
+
+			var block *ethTypes.Block
+
+			block, err = e.chain.GetBlockByNumber(big.NewInt(int64(blockNum)))
+
+			chainServiceBlock := chainservice.Block{
+				BlockNum:  block.NumberU64(),
+				Timestamp: block.Time(),
+			}
+
+			e.checkError(err)
+
+			err = e.processStoreChannels(chainServiceBlock)
 		case <-ctx.Done():
 			e.wg.Done()
 			return


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Use confirmed block (3 blocks behind head) in block ticker for processing store channels
- Use new channel to listen for new blocks while waiting for approval event (during direct fund)
- TODO to be completed in follow on PR:
  - Add CLI to trigger chain tx of an objective if previous tx does not go through (due to chain reorgs)