### PR TITLE
Implement method to counter challenge mirror bridged defund challenge

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	nodeutils "github.com/statechannels/go-nitro/internal/node"
 	"github.com/statechannels/go-nitro/node"
@@ -399,6 +400,18 @@ func (b *Bridge) updateOnchainAssetAddressMap() error {
 // Since bridge node addresses are same
 func (b Bridge) GetBridgeAddress() common.Address {
 	return *b.nodeL1.Address
+}
+
+func (b Bridge) GetL2SupportedSignedState(id types.Destination) (state.SignedState, error) {
+	return b.nodeL2.GetSignedState(id)
+}
+
+func (b Bridge) MirrorBridgedDefund(l1ChannelId types.Destination, l2SignedState state.SignedState, isChallenge bool) (protocols.ObjectiveId, error) {
+	return b.nodeL1.MirrorBridgedDefund(l1ChannelId, l2SignedState, isChallenge)
+}
+
+func (b Bridge) CounterChallenge(id types.Destination, action types.CounterChallengeAction, payload interface{}) {
+	b.nodeL1.CounterChallenge(id, action, payload)
 }
 
 func (b Bridge) GetL2ChannelIdByL1ChannelId(l1ChannelId types.Destination) (l2ChannelId types.Destination, isCreated bool) {

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -410,7 +410,7 @@ func (b Bridge) MirrorBridgedDefund(l1ChannelId types.Destination, l2SignedState
 	return b.nodeL1.MirrorBridgedDefund(l1ChannelId, l2SignedState, isChallenge)
 }
 
-func (b Bridge) CounterChallenge(id types.Destination, action types.CounterChallengeAction, payload interface{}) {
+func (b Bridge) CounterChallenge(id types.Destination, action types.CounterChallengeAction, payload state.SignedState) {
 	b.nodeL1.CounterChallenge(id, action, payload)
 }
 

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -195,7 +195,7 @@ type ChainService interface {
 	GetLastConfirmedBlockNum() uint64
 	// GetLatestBlock returns the latest block
 	GetLatestBlock() Block
-	// TODO: Implement method for eth calls
+	// TODO: Implement method for eth calls (similar to sendTransaction method)
 	// GetL1ChannelFromL2 returns the L1 ledger channel ID from the L2 ledger channel by making a contract call to the l2ToL1 map of the Nitro Adjudicator contract
 	GetL1ChannelFromL2(l2Channel types.Destination) (types.Destination, error)
 	GetL1AssetAddressFromL2(l2AssetAddress common.Address) (common.Address, error)

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -469,6 +469,17 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 				return EngineEvent{}, err
 			}
 			c = channel
+		} else if _, isChallengeCleared := chainEvent.(chainservice.ChallengeClearedEvent); isChallengeCleared {
+			l1ChannelId, err := e.chain.GetL1ChannelFromL2(chainEvent.ChannelID())
+			if err != nil {
+				slog.Debug("l1 channel id not found from chain")
+			}
+
+			l1Channel, ok := e.store.GetChannelById(l1ChannelId)
+
+			if ok {
+				c = l1Channel
+			}
 		} else {
 			// TODO: Right now the chain service returns chain events for ALL channels even those we aren't involved in
 			// for now we can ignore channels we aren't involved in
@@ -754,10 +765,14 @@ func (e *Engine) handleCounterChallengeRequest(request types.CounterChallengeReq
 
 	case *mirrorbridgeddefund.Objective:
 		if isCheckPoint {
+			payload, _ := request.Payload.(state.SignedState)
 			objective.IsCheckPoint = isCheckPoint
+			objective.L2SignedState = payload
 		}
 		if isChallenge {
 			objective.IsChallenge = isChallenge
+			payload, _ := request.Payload.(state.SignedState)
+			objective.L2SignedState = payload
 		}
 		_, err := e.attemptProgress(objective)
 		if err != nil {

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -673,28 +673,50 @@ func (e *Engine) handlePaymentRequest(request PaymentRequest) (EngineEvent, erro
 
 // handleCounterChallengeRequest handles a counter challenge request for the given channel.
 func (e *Engine) handleCounterChallengeRequest(request types.CounterChallengeRequest) error {
-	objective, err := e.store.GetObjectiveById(protocols.ObjectiveId(directdefund.ObjectivePrefix + request.ChannelId.String()))
-	if err != nil {
-		return err
-	}
-	obj, ok := objective.(*directdefund.Objective)
-
-	if !ok {
-		return fmt.Errorf("direct defund objective required")
-	}
+	channelId := request.ChannelId
+	isCheckPoint := false
+	isChallenge := false
 
 	switch request.Action {
 	case types.Checkpoint:
-		obj.IsCheckpoint = true
+		isCheckPoint = true
 	case types.Challenge:
-		obj.IsChallenge = true
+		isChallenge = true
 	default:
 		return fmt.Errorf("unknown counter challenge action")
 	}
 
-	_, err = e.attemptProgress(objective)
-	if err != nil {
-		return err
+	obj, ok := e.store.GetObjectiveByChannelId(channelId)
+	if !ok {
+		return fmt.Errorf("objective to process the counter challenge request for channel Id %s could not be found", channelId.String())
+	}
+
+	switch objective := obj.(type) {
+	case *directdefund.Objective:
+		if isCheckPoint {
+			objective.IsCheckpoint = isCheckPoint
+		}
+		if isChallenge {
+			objective.IsChallenge = isChallenge
+		}
+		_, err := e.attemptProgress(objective)
+		if err != nil {
+			return err
+		}
+
+	case *mirrorbridgeddefund.Objective:
+		if isCheckPoint {
+			objective.IsCheckPoint = isCheckPoint
+		}
+		if isChallenge {
+			objective.IsChallenge = isChallenge
+		}
+		_, err := e.attemptProgress(objective)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown objective type %T", objective)
 	}
 
 	return nil

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -722,16 +722,8 @@ func (e *Engine) handleCounterChallengeRequest(request CounterChallengeRequest) 
 
 	switch objective := obj.(type) {
 	case *directdefund.Objective:
-		if isCheckPoint {
-			objective.IsCheckpoint = isCheckPoint
-		}
-		if isChallenge {
-			objective.IsChallenge = isChallenge
-		}
-		_, err := e.attemptProgress(objective)
-		if err != nil {
-			return err
-		}
+		objective.IsCheckpoint = isCheckPoint
+		objective.IsChallenge = isChallenge
 
 	case *mirrorbridgeddefund.Objective:
 		if request.Payload.State().ChannelId().IsZero() {
@@ -739,18 +731,16 @@ func (e *Engine) handleCounterChallengeRequest(request CounterChallengeRequest) 
 		}
 
 		objective.L2SignedState = request.Payload
-		if isCheckPoint {
-			objective.IsCheckPoint = isCheckPoint
-		}
-		if isChallenge {
-			objective.IsChallenge = isChallenge
-		}
-		_, err := e.attemptProgress(objective)
-		if err != nil {
-			return err
-		}
+		objective.IsCheckPoint = isCheckPoint
+		objective.IsChallenge = isChallenge
+
 	default:
 		return fmt.Errorf("unknown objective type %T", objective)
+	}
+
+	_, err := e.attemptProgress(obj)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -455,7 +455,7 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 	_, isChallengeCleared := chainEvent.(chainservice.ChallengeClearedEvent)
 
 	if isChallengeRegistered || isChallengeCleared {
-		l1ChannelId, err := e.ProcessL2Channel(chainEvent, isChallengeRegistered)
+		l1ChannelId, err := e.processL2Channel(chainEvent, isChallengeRegistered)
 		if err != nil {
 			return EngineEvent{}, err
 		}
@@ -542,9 +542,9 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 	return EngineEvent{}, nil
 }
 
-// ProcessL2Channel checks if the chain event corresponds to an L2 channel and retrieves its L1 channel ID.
+// processL2Channel checks if the chain event corresponds to an L2 channel and retrieves its L1 channel ID.
 // If the L1 channel doesn't exist, it creates a mirror bridged defund objective.
-func (e *Engine) ProcessL2Channel(chainEvent chainservice.Event, isChallengeRegistered bool) (types.Destination, error) {
+func (e *Engine) processL2Channel(chainEvent chainservice.Event, isChallengeRegistered bool) (types.Destination, error) {
 	// Check whether a challenge has been registered / cleared for the L2 channel, and then retrieve its L1 channel using an eth call to NitroAdjudicator contract
 	l1ChannelId, err := e.chain.GetL1ChannelFromL2(chainEvent.ChannelID())
 	if err != nil {
@@ -552,7 +552,6 @@ func (e *Engine) ProcessL2Channel(chainEvent chainservice.Event, isChallengeRegi
 	}
 
 	if !l1ChannelId.IsZero() {
-
 		_, ok := e.store.GetChannelById(l1ChannelId)
 		if ok {
 			return l1ChannelId, nil

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -455,8 +455,12 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 	_, isChallengeCleared := chainEvent.(chainservice.ChallengeClearedEvent)
 
 	if isChallengeRegistered || isChallengeCleared {
-		l1ChannelId, err := e.processL2Channel(chainEvent, isChallengeRegistered)
+		l1ChannelId, err := e.checkAndProcessL2Channel(chainEvent, isChallengeRegistered)
 		if err != nil {
+			if errors.Is(err, mirrorbridgeddefund.ErrChannelNotExist) {
+				return EngineEvent{}, nil
+			}
+
 			return EngineEvent{}, err
 		}
 
@@ -542,42 +546,44 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 	return EngineEvent{}, nil
 }
 
-// processL2Channel checks if the chain event corresponds to an L2 channel and retrieves its L1 channel ID.
+// checkAndProcessL2Channel checks if the chain event corresponds to an L2 channel and retrieves its L1 channel ID.
 // If the L1 channel doesn't exist, it creates a mirror bridged defund objective.
-func (e *Engine) processL2Channel(chainEvent chainservice.Event, isChallengeRegistered bool) (types.Destination, error) {
+func (e *Engine) checkAndProcessL2Channel(chainEvent chainservice.Event, isChallengeRegistered bool) (types.Destination, error) {
 	// Check whether a challenge has been registered / cleared for the L2 channel, and then retrieve its L1 channel using an eth call to NitroAdjudicator contract
 	l1ChannelId, err := e.chain.GetL1ChannelFromL2(chainEvent.ChannelID())
 	if err != nil {
 		return types.Destination{}, err
 	}
 
-	if !l1ChannelId.IsZero() {
-		_, ok := e.store.GetChannelById(l1ChannelId)
-		if ok {
-			return l1ChannelId, nil
+	if l1ChannelId.IsZero() {
+		return types.Destination{}, nil
+	}
+
+	_, ok := e.store.GetChannelById(l1ChannelId)
+	if ok {
+		return l1ChannelId, nil
+	}
+
+	// If channel doesn't exist and chain event is ChallengeRegistered on L2 then create a new mirror bridged defund objective
+	// This doesn't occur for actor who registered the challenge on L2
+	if isChallengeRegistered && !ok {
+		mbdfo, err := mirrorbridgeddefund.NewObjective(mirrorbridgeddefund.NewObjectiveRequest(l1ChannelId, state.SignedState{}, false), true, e.store.GetConsensusChannelById, true)
+		if err != nil {
+			return types.Destination{}, err
 		}
 
-		// If channel doesn't exist and chain event is ChallengeRegistered on L2 then create a new mirror bridged defund objective
-		// This doesn't occur for actor who registered the challenge on L2
-		if isChallengeRegistered && !ok {
-			mbdfo, err := mirrorbridgeddefund.NewObjective(mirrorbridgeddefund.NewObjectiveRequest(l1ChannelId, state.SignedState{}, false), true, e.store.GetConsensusChannelById, true)
-			if err != nil {
-				return types.Destination{}, err
-			}
-
-			// Destroy the consensus channel to prevent it being used (Channel will now take over governance)
-			err = e.store.DestroyConsensusChannel(mbdfo.C.Id)
-			if err != nil {
-				return types.Destination{}, err
-			}
-
-			err = e.store.SetObjective(&mbdfo)
-			if err != nil {
-				return types.Destination{}, err
-			}
-
-			return l1ChannelId, nil
+		// Destroy the consensus channel to prevent it being used (Channel will now take over governance)
+		err = e.store.DestroyConsensusChannel(mbdfo.C.Id)
+		if err != nil {
+			return types.Destination{}, err
 		}
+
+		err = e.store.SetObjective(&mbdfo)
+		if err != nil {
+			return types.Destination{}, err
+		}
+
+		return l1ChannelId, nil
 	}
 
 	return types.Destination{}, nil
@@ -957,7 +963,7 @@ func (e Engine) spawnConsensusChannelIfBridgedFundObjective(crankedObjective pro
 func (e Engine) destroyObjectiveAndChannelIfChallengeCleared(crankedObjective protocols.Objective) error {
 	var objectiveToDelete protocols.Objective
 	var consensusChannel *consensus_channel.ConsensusChannel
-	var destoryObjectiveAndChannel bool
+	var isObjectiveFullyWithdrawn bool
 
 	// TODO: Create interface for defund objectives
 	switch objective := crankedObjective.(type) {
@@ -970,7 +976,7 @@ func (e Engine) destroyObjectiveAndChannelIfChallengeCleared(crankedObjective pr
 
 			objectiveToDelete = objective
 			consensusChannel = cc
-			destoryObjectiveAndChannel = true
+			isObjectiveFullyWithdrawn = true
 		}
 
 	case *mirrorbridgeddefund.Objective:
@@ -982,11 +988,11 @@ func (e Engine) destroyObjectiveAndChannelIfChallengeCleared(crankedObjective pr
 
 			objectiveToDelete = objective
 			consensusChannel = cc
-			destoryObjectiveAndChannel = true
+			isObjectiveFullyWithdrawn = true
 		}
 	}
 
-	if destoryObjectiveAndChannel {
+	if isObjectiveFullyWithdrawn {
 		err := e.store.SetConsensusChannel(consensusChannel)
 		if err != nil {
 			return fmt.Errorf("could not store consensus channel for objective %s: %w", crankedObjective.Id(), err)

--- a/node/node.go
+++ b/node/node.go
@@ -393,6 +393,6 @@ func (n *Node) handleError(err error) {
 	}
 }
 
-func (n *Node) CounterChallenge(id types.Destination, action types.CounterChallengeAction, payload interface{}) {
-	n.engine.CounterChallengeRequestsFromAPI <- types.CounterChallengeRequest{ChannelId: id, Action: action, Payload: payload}
+func (n *Node) CounterChallenge(id types.Destination, action types.CounterChallengeAction, payload state.SignedState) {
+	n.engine.CounterChallengeRequestsFromAPI <- engine.CounterChallengeRequest{ChannelId: id, Action: action, Payload: payload}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -393,6 +393,6 @@ func (n *Node) handleError(err error) {
 	}
 }
 
-func (n *Node) CounterChallenge(id types.Destination, action types.CounterChallengeAction) {
-	n.engine.CounterChallengeRequestsFromAPI <- types.CounterChallengeRequest{ChannelId: id, Action: action}
+func (n *Node) CounterChallenge(id types.Destination, action types.CounterChallengeAction, payload interface{}) {
+	n.engine.CounterChallengeRequestsFromAPI <- types.CounterChallengeRequest{ChannelId: id, Action: action, Payload: payload}
 }

--- a/node/query/types.go
+++ b/node/query/types.go
@@ -60,7 +60,7 @@ func (lcb LedgerChannelBalance) Equal(other LedgerChannelBalance) bool {
 
 // Equal returns true if the other LedgerChannelInfo is equal to this one
 func (li LedgerChannelInfo) Equal(other LedgerChannelInfo) bool {
-	return li.ID == other.ID && li.Status == other.Status && li.Balance.Equal(other.Balance)
+	return li.ID == other.ID && li.Status == other.Status && li.Balance.Equal(other.Balance) && li.ChannelMode == other.ChannelMode
 }
 
 // Equal returns true if the other PaymentChannelInfo is equal to this one

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -304,8 +304,167 @@ func TestBridgedFundWithCheckpoint(t *testing.T) {
 			}
 		}
 
-		// TODO: Check off-chain balance does not match on-chain balance
-		// checkLedgerChannel(t, l1LedgerChannelId, ledgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, payAmount, types.Address{}), query.Complete, nodeA)
+		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
+		balanceBridge, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())
+		t.Logf("Balance of node A %v \nBalance of Bridge %v", balanceNodeA, balanceBridge)
+
+		// NodeA's balance is determined by subtracting amount paid from it's ledger deposit, while Bridge's balance is calculated by adding the amount received
+		testhelpers.Assert(t, balanceNodeA.Cmp(big.NewInt(ledgerChannelDeposit-payAmount)) == 0, "Balance of node A (%v) should be equal to (%v)", balanceNodeA, ledgerChannelDeposit-payAmount)
+		testhelpers.Assert(t, balanceBridge.Cmp(big.NewInt(payAmount)) == 0, "Balance of Bridge (%v) should be equal to (%v)", balanceBridge, payAmount)
+	})
+}
+
+func TestBridgedFundWithCounterChallenge(t *testing.T) {
+	tcL1 := TestCase{
+		Chain:             AnvilChainL1,
+		MessageService:    P2PMessageService,
+		MessageDelay:      0,
+		LogName:           "Bridge_test",
+		ChallengeDuration: 15,
+		Participants: []TestParticipant{
+			{StoreType: MemStore, Actor: testactors.Alice},
+			{StoreType: MemStore, Actor: testactors.Bob},
+		},
+		deployerIndex: 1,
+	}
+
+	tcL2 := TestCase{
+		Chain:             AnvilChainL2,
+		MessageService:    P2PMessageService,
+		MessageDelay:      0,
+		LogName:           "Bridge_test",
+		ChallengeDuration: 15,
+		Participants: []TestParticipant{
+			{StoreType: MemStore, Actor: testactors.BobPrime},
+			{StoreType: MemStore, Actor: testactors.AlicePrime},
+		},
+		ChainPort:     "8546",
+		deployerIndex: 0,
+	}
+
+	dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
+	defer cleanup()
+
+	infraL1 := setupSharedInfra(tcL1)
+	defer infraL1.Close(t)
+
+	infraL2 := setupSharedInfra(tcL2)
+	defer infraL2.Close(t)
+
+	bridgeConfig := bridge.BridgeConfig{
+		L1ChainUrl:        infraL1.anvilChain.ChainUrl,
+		L2ChainUrl:        infraL2.anvilChain.ChainUrl,
+		L1ChainStartBlock: 0,
+		L2ChainStartBlock: 0,
+		ChainPK:           infraL1.anvilChain.ChainPks[tcL1.Participants[1].ChainAccountIndex],
+		StateChannelPK:    common.Bytes2Hex(tcL1.Participants[1].PrivateKey),
+		NaAddress:         infraL1.anvilChain.ContractAddresses.NaAddress.String(),
+		VpaAddress:        infraL1.anvilChain.ContractAddresses.VpaAddress.String(),
+		CaAddress:         infraL1.anvilChain.ContractAddresses.CaAddress.String(),
+		BridgeAddress:     infraL2.anvilChain.ContractAddresses.BridgeAddress.String(),
+		DurableStoreDir:   dataFolder,
+		BridgePublicIp:    DEFAULT_PUBLIC_IP,
+		NodeL1MsgPort:     int(tcL1.Participants[1].Port),
+		NodeL2MsgPort:     int(tcL2.Participants[0].Port),
+	}
+
+	bridge := bridge.New()
+	bridgeMultiaddressL1, bridgeMultiaddressL2, err := bridge.Start(bridgeConfig)
+	if err != nil {
+		t.Log("error in starting bridge", err)
+	}
+	defer bridge.Close()
+	bridgeAddress := bridge.GetBridgeAddress()
+
+	nodeA, _, _, _, _ := setupIntegrationNode(tcL1, tcL1.Participants[0], infraL1, []string{bridgeMultiaddressL1}, dataFolder)
+	defer nodeA.Close()
+
+	nodeAPrime, _, _, storeAPrime, _ := setupIntegrationNode(tcL2, tcL2.Participants[1], infraL2, []string{bridgeMultiaddressL2}, dataFolder)
+	defer nodeAPrime.Close()
+
+	var l1LedgerChannelId types.Destination
+	var l2LedgerChannelId types.Destination
+	var oldL2SignedState state.SignedState
+
+	t.Run("Create ledger channel on L1 and mirror it on L2", func(t *testing.T) {
+		// Alice create ledger channel with bridge
+		outcome := ledgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, types.Address{})
+		l1LedgerChannelResponse, err := nodeA.CreateLedgerChannel(bridgeAddress, uint32(tcL1.ChallengeDuration), outcome)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log("Waiting for direct-fund objective to complete...")
+		l1LedgerChannelId = l1LedgerChannelResponse.ChannelId
+		<-nodeA.ObjectiveCompleteChan(l1LedgerChannelResponse.Id)
+		t.Log("L1 channel created", l1LedgerChannelResponse.Id)
+
+		// Wait for mirror channel to be created
+		completedMirrorChannel := <-bridge.CompletedMirrorChannels()
+		l2LedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
+
+		cc, err := storeAPrime.GetConsensusChannelById(l2LedgerChannelId)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		oldL2SignedState = cc.SupportedSignedState()
+
+		testhelpers.Assert(t, completedMirrorChannel == l2LedgerChannelId, "Expects mirror channel id to be %v", l2LedgerChannelId)
+		checkLedgerChannel(t, l1LedgerChannelResponse.ChannelId, ledgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, types.Address{}), query.Open, nodeA)
+		checkLedgerChannel(t, l2LedgerChannelId, ledgerOutcome(bridgeAddress, *nodeAPrime.Address, 0, ledgerChannelDeposit, types.Address{}), query.Open, nodeAPrime)
+	})
+
+	t.Run("Create virtual channel on mirrored ledger channel and make payments", func(t *testing.T) {
+		// Create virtual channel on mirrored ledger channel on L2
+		virtualOutcome := initialPaymentOutcome(*nodeAPrime.Address, bridgeAddress, types.Address{})
+		virtualResponse, _ := nodeAPrime.CreatePaymentChannel([]types.Address{}, bridgeAddress, uint32(tcL2.ChallengeDuration), virtualOutcome)
+		<-nodeAPrime.ObjectiveCompleteChan(virtualResponse.Id)
+		checkPaymentChannel(t, virtualResponse.ChannelId, virtualOutcome, query.Open, nodeAPrime)
+
+		// APrime pays BPrime
+		nodeAPrime.Pay(virtualResponse.ChannelId, big.NewInt(payAmount))
+
+		// Virtual defund
+		virtualDefundResponse, _ := nodeAPrime.ClosePaymentChannel(virtualResponse.ChannelId)
+		<-nodeAPrime.ObjectiveCompleteChan(virtualDefundResponse)
+
+		ledgerChannelInfo, _ := nodeAPrime.GetLedgerChannel(l2LedgerChannelId)
+		balanceNodeBPrime := ledgerChannelInfo.Balance.TheirBalance.ToInt()
+		balanceNodeAPrime := ledgerChannelInfo.Balance.MyBalance.ToInt()
+		t.Log("Balance of node BPrime", balanceNodeBPrime, "\nBalance of node APrime", balanceNodeAPrime)
+
+		// APrime's balance is determined by subtracting amount paid from it's ledger deposit, while BPrime's balance is calculated by adding the amount received
+		testhelpers.Assert(t, balanceNodeBPrime.Cmp(big.NewInt(payAmount)) == 0, "Balance of node BPrime (%v) should be equal to (%v)", balanceNodeBPrime, ledgerChannelDeposit+payAmount)
+		testhelpers.Assert(t, balanceNodeAPrime.Cmp(big.NewInt(ledgerChannelDeposit-payAmount)) == 0, "Balance of node APrime (%v) should be equal to (%v)", balanceNodeAPrime, ledgerChannelDeposit-payAmount)
+	})
+
+	t.Run("Unilaterally exit to L1 using updated L2 ledger channel state after making payments", func(t *testing.T) {
+		ledgerUpdatesChannelNodeA := nodeA.LedgerUpdatedChan(l1LedgerChannelId)
+		ch := nodeA.CompletedObjectives()
+
+		// Alice unilaterally exits from L1 using old L2 signed state
+		_, err = nodeA.MirrorBridgedDefund(l1LedgerChannelId, oldL2SignedState, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		newL2signedState, err := bridge.GetL2SupportedSignedState(l2LedgerChannelId)
+		if err != nil {
+			t.Log(err)
+		}
+
+		// Wait for Alice's challenge to be registered
+		listenForLedgerUpdates(ledgerUpdatesChannelNodeA, channel.Challenge)
+
+		// Bridge counters the Alice' challenge
+		bridge.CounterChallenge(l1LedgerChannelId, types.Challenge, newL2signedState)
+
+		// Wait for mirror bridged defund to complete
+		for val := range ch {
+			if val == protocols.ObjectiveId(mirrorbridgeddefund.ObjectivePrefix+l1LedgerChannelId.String()) {
+				break
+			}
+		}
 
 		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
 		balanceBridge, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -266,7 +266,7 @@ func TestBridgedFundWithCheckpoint(t *testing.T) {
 		testhelpers.Assert(t, balanceNodeAPrime.Cmp(big.NewInt(ledgerChannelDeposit-payAmount)) == 0, "Balance of node APrime (%v) should be equal to (%v)", balanceNodeAPrime, ledgerChannelDeposit-payAmount)
 	})
 
-	t.Run("Unilaterally exit to L1 using updated L2 ledger channel state after making payments", func(t *testing.T) {
+	t.Run("Clear the registered challenge using checkpoint and exit L2 using latest L2 state", func(t *testing.T) {
 		ledgerUpdatesChannelNodeA := nodeA.LedgerUpdatedChan(l1LedgerChannelId)
 		completedObjectiveChannel := nodeA.CompletedObjectives()
 
@@ -284,10 +284,10 @@ func TestBridgedFundWithCheckpoint(t *testing.T) {
 		// Wait for challenge registered event
 		listenForLedgerUpdates(ledgerUpdatesChannelNodeA, channel.Challenge)
 
-		// Bridge clears the challenge
+		// Bridge clears the challenge using new L2 signed state
 		bridge.CounterChallenge(l1LedgerChannelId, types.Checkpoint, newL2signedState)
 
-		// Wait for mirror bridged defund to complete
+		// Wait for mirror bridged defund to complete on L1 (objective is completed after the challenge cleared event occurs)
 		for val := range completedObjectiveChannel {
 			if val == protocols.ObjectiveId(mirrorbridgeddefund.ObjectivePrefix+l1LedgerChannelId.String()) {
 				break
@@ -451,7 +451,7 @@ func TestBridgedFundWithCounterChallenge(t *testing.T) {
 		testhelpers.Assert(t, balanceNodeAPrime.Cmp(big.NewInt(ledgerChannelDeposit-payAmount)) == 0, "Balance of node APrime (%v) should be equal to (%v)", balanceNodeAPrime, ledgerChannelDeposit-payAmount)
 	})
 
-	t.Run("Unilaterally exit to L1 using updated L2 ledger channel state after making payments", func(t *testing.T) {
+	t.Run("Counter the registered challenge by challenging with new L2 state and exit L2 using the new L2 state", func(t *testing.T) {
 		ledgerUpdatesChannelNodeA := nodeA.LedgerUpdatedChan(l1LedgerChannelId)
 		completedObjectiveChannel := nodeA.CompletedObjectives()
 
@@ -469,7 +469,7 @@ func TestBridgedFundWithCounterChallenge(t *testing.T) {
 		// Wait for Alice's challenge to be registered
 		listenForLedgerUpdates(ledgerUpdatesChannelNodeA, channel.Challenge)
 
-		// Bridge counters the Alice' challenge
+		// Bridge counters the Alice' challenge using new L2 signed state
 		bridge.CounterChallenge(l1LedgerChannelId, types.Challenge, newL2signedState)
 
 		// Wait for mirror bridged defund to complete on L1

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -467,166 +467,6 @@ func TestBridgedFundWithChallenge(t *testing.T) {
 	})
 }
 
-func TestL2ChallengeAndCounterChallenge(t *testing.T) {
-	utils, cleanupUtils := initializeUtils(t, true)
-	defer cleanupUtils()
-
-	tcL1, tcL2 := utils.tcL1, utils.tcL2
-	nodeA, nodeB := utils.nodeA, utils.nodeB
-	nodeAPrime, nodeBPrime := utils.nodeAPrime, utils.nodeBPrime
-	chainServiceA, chainServiceB := utils.chainServiceA, utils.chainServiceB
-	testChainService := utils.testChainService
-	storeA := utils.storeA
-	storeAPrime, storeBPrime := utils.storeAPrime, utils.storeBPrime
-	infraL1 := utils.infraL1
-
-	challengeRegisteredEvent := chainservice.ChallengeRegisteredEvent{}
-
-	// Create ledger channel on L1 and mirror it on L2
-	l1ChannelId, mirroredLedgerChannelId := createL1L2Channels(t, nodeA, nodeB, nodeAPrime, nodeBPrime, storeA, tcL1, tcL2, chainServiceB)
-
-	oldL2SignedState := getLatestSignedState(storeAPrime, mirroredLedgerChannelId)
-	var newL2SignedState state.SignedState
-	// Create virtual channel on mirrored ledger channel and make payments
-	virtualChannel := createL2VirtualChannel(t, nodeBPrime, nodeAPrime, storeBPrime, tcL2)
-
-	// APrime pays Bridge
-	err := nodeAPrime.Pay(virtualChannel.Id, big.NewInt(payAmount))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Wait for Bridge to recieve voucher
-	bridgeVoucher := <-nodeBPrime.ReceivedVouchers()
-	t.Logf("Voucher recieved %+v", bridgeVoucher)
-
-	// Virtual defund
-	virtualDefundResponse, _ := nodeAPrime.ClosePaymentChannel(virtualChannel.Id)
-	waitForObjectives(t, nodeAPrime, nodeBPrime, []node.Node{}, []protocols.ObjectiveId{virtualDefundResponse})
-
-	t.Run("Challenge L1 channel with older L2 signed state", func(t *testing.T) {
-		// Node A calls `challenge` contract method with L2 ledger channel state
-		challengerSig, _ := NitroAdjudicator.SignChallengeMessage(oldL2SignedState.State(), tcL1.Participants[0].PrivateKey)
-		challengeTx := protocols.NewChallengeTransaction(l1ChannelId, oldL2SignedState, []state.SignedState{}, challengerSig)
-		err := chainServiceA.SendTransaction(challengeTx)
-		if err != nil {
-			t.Error(err)
-		}
-
-		event := waitForEvent(t, testChainService.EventFeed(), chainservice.ChallengeRegisteredEvent{})
-		t.Log("Challenge registed event received", event)
-		challengeRegistered, ok := event.(chainservice.ChallengeRegisteredEvent)
-		challengeRegisteredEvent = challengeRegistered
-		testhelpers.Assert(t, ok, "Expected challenge registered event")
-	})
-
-	t.Run("Respond to challenge with a checkpoint using newer signed state", func(t *testing.T) {
-		newL2SignedState = getLatestSignedState(storeBPrime, mirroredLedgerChannelId)
-		// Bridge calls checkpoint method using new state
-		checkpointTx := protocols.NewCheckpointTransaction(l1ChannelId, newL2SignedState, make([]state.SignedState, 0))
-		err = chainServiceB.SendTransaction(checkpointTx)
-		if err != nil {
-			t.Error(err)
-		}
-		// Listen for challenge cleared event
-		event := waitForEvent(t, testChainService.EventFeed(), chainservice.ChallengeClearedEvent{})
-		t.Log("Challenge cleared event received", event)
-		challengeClearedEvent, ok := event.(chainservice.ChallengeClearedEvent)
-		testhelpers.Assert(t, ok, "Expected challenge cleared event")
-		testhelpers.Assert(t, challengeClearedEvent.ChannelID() == newL2SignedState.State().ChannelId(), "Channel ID mismatch")
-		latestBlock, _ := infraL1.anvilChain.GetLatestBlock()
-		testhelpers.Assert(t, challengeRegisteredEvent.FinalizesAt.Uint64() <= latestBlock.Header().Time, "Expected challenge duration to be completed")
-
-		// Alice attempts to exit, but the attempt fails because the outcome has not been finalized
-		transferTx := protocols.NewMirrorTransferAllTransaction(l1ChannelId, oldL2SignedState)
-		err = chainServiceA.SendTransaction(transferTx)
-		testhelpers.Assert(t, err.Error() == "execution reverted: revert: Channel not finalized.", "Expected execution reverted error")
-	})
-
-	t.Run("Make payment after checkpoint and virtual defund", func(t *testing.T) {
-		// Create virtual channel on mirrored ledger channel and make payments (since channel is open)
-		virtualChannel := createL2VirtualChannel(t, nodeBPrime, nodeAPrime, storeBPrime, tcL2)
-		oldL2SignedState = getLatestSignedState(storeAPrime, mirroredLedgerChannelId)
-
-		// APrime pays Bridge
-		err := nodeAPrime.Pay(virtualChannel.Id, big.NewInt(payAmount))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Wait for Bridge to recieve voucher
-		bridgeVoucher := <-nodeBPrime.ReceivedVouchers()
-		t.Logf("Voucher recieved %+v", bridgeVoucher)
-
-		// Virtual defund
-		virtualDefundResponse, _ := nodeAPrime.ClosePaymentChannel(virtualChannel.Id)
-		waitForObjectives(t, nodeAPrime, nodeBPrime, []node.Node{}, []protocols.ObjectiveId{virtualDefundResponse})
-		newL2SignedState = getLatestSignedState(storeBPrime, mirroredLedgerChannelId)
-	})
-
-	t.Run("Respond to challenge with a counter challenge using newer signed state", func(t *testing.T) {
-		// Alice challenges with old L2 ledger channel state
-		challengerSig, _ := NitroAdjudicator.SignChallengeMessage(oldL2SignedState.State(), tcL1.Participants[0].PrivateKey)
-		challengeTx := protocols.NewChallengeTransaction(l1ChannelId, oldL2SignedState, []state.SignedState{}, challengerSig)
-		err := chainServiceA.SendTransaction(challengeTx)
-		if err != nil {
-			t.Error(err)
-		}
-
-		event := waitForEvent(t, testChainService.EventFeed(), chainservice.ChallengeRegisteredEvent{})
-		t.Log("Challenge registed event received", event)
-		challengeRegistered, ok := event.(chainservice.ChallengeRegisteredEvent)
-		challengeRegisteredEvent = challengeRegistered
-		testhelpers.Assert(t, ok, "Expected challenge registered event")
-
-		// Bob counter challenges with new L2 ledger channel state
-		challengerSig, _ = NitroAdjudicator.SignChallengeMessage(newL2SignedState.State(), tcL1.Participants[1].PrivateKey)
-		challengeTx = protocols.NewChallengeTransaction(l1ChannelId, newL2SignedState, []state.SignedState{}, challengerSig)
-		err = chainServiceB.SendTransaction(challengeTx)
-		if err != nil {
-			t.Error(err)
-		}
-
-		event = waitForEvent(t, testChainService.EventFeed(), chainservice.ChallengeRegisteredEvent{})
-		t.Log("Challenge registed event received", event)
-		challengeRegistered, ok = event.(chainservice.ChallengeRegisteredEvent)
-		challengeRegisteredEvent = challengeRegistered
-		testhelpers.Assert(t, ok, "Expected challenge registered event")
-
-		// Wait for the challenge duration to allow the channel to finalize
-		time.Sleep(time.Duration(tcL1.ChallengeDuration) * time.Second)
-		latestBlock, _ := infraL1.anvilChain.GetLatestBlock()
-		testhelpers.Assert(t, challengeRegisteredEvent.FinalizesAt.Uint64() <= latestBlock.Header().Time, "Expected channel to be finalized")
-
-		testhelpers.Assert(t, challengeRegisteredEvent.ChannelID() == newL2SignedState.State().ChannelId(), "Channel ID mismatch")
-
-		// Alice attempts to exit with old l2 channel state but the attempt fails because of incorrect fingerprint
-		transferTx := protocols.NewMirrorTransferAllTransaction(l1ChannelId, oldL2SignedState)
-		err = chainServiceA.SendTransaction(transferTx)
-		testhelpers.Assert(t, err.Error() == "execution reverted: revert: incorrect fingerprint", "Expected execution reverted error")
-
-		// Bob liquidates the channel based on new L2 ledger channel state
-		transferTx = protocols.NewMirrorTransferAllTransaction(l1ChannelId, newL2SignedState)
-		err = chainServiceB.SendTransaction(transferTx)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Listen for allocation updated event
-		event = waitForEvent(t, testChainService.EventFeed(), chainservice.AllocationUpdatedEvent{})
-		_, ok = event.(chainservice.AllocationUpdatedEvent)
-		testhelpers.Assert(t, ok, "Expected allocation updated event")
-
-		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
-		balanceNodeB, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())
-		t.Log("Balance of node A", balanceNodeA, "\nBalance of node B", balanceNodeB)
-
-		// Alice's balance is calculated by subtracting twice the amount she paid from her ledger deposit, whereas Bob's balance is determined by adding his ledger deposit to twice the amount he received (as the payment was made twice)
-		testhelpers.Assert(t, balanceNodeA.Cmp(big.NewInt(ledgerChannelDeposit-2*payAmount)) == 0, "Balance of node A (%v) should be equal to (%v)", balanceNodeA, ledgerChannelDeposit-2*payAmount)
-		testhelpers.Assert(t, balanceNodeB.Cmp(big.NewInt(ledgerChannelDeposit+2*payAmount)) == 0, "Balance of node B (%v) should be equal to (%v)", balanceNodeB, ledgerChannelDeposit+2*payAmount)
-	})
-}
-
 func TestExitL2WithVirtualChannelStateUnilaterally(t *testing.T) {
 	utils, cleanupUtils := initializeUtils(t, false)
 	defer cleanupUtils()
@@ -634,7 +474,7 @@ func TestExitL2WithVirtualChannelStateUnilaterally(t *testing.T) {
 	tcL1, tcL2 := utils.tcL1, utils.tcL2
 	nodeA, nodeB := utils.nodeA, utils.nodeB
 	nodeAPrime, nodeBPrime := utils.nodeAPrime, utils.nodeBPrime
-	chainServiceA, chainServiceB := utils.chainServiceA, utils.chainServiceB
+	chainServiceB := utils.chainServiceB
 	testChainService := utils.testChainService
 	storeA := utils.storeA
 	storeAPrime, storeBPrime := utils.storeAPrime, utils.storeBPrime
@@ -711,10 +551,13 @@ func TestExitL2WithVirtualChannelStateUnilaterally(t *testing.T) {
 		signedVirtualState, _ := updatedVirtualChannel.LatestSignedState()
 		signedPostFundState := updatedVirtualChannel.SignedPostFundState()
 
+		// Close Alice node to prevent creating objective from chain events and use test chain service for sending transactions
+		nodeA.Close()
+
 		// Node A calls modified `challenge` with L2 virtual channel state
 		virtualChallengerSig, _ := NitroAdjudicator.SignChallengeMessage(signedVirtualState.State(), tcL1.Participants[0].PrivateKey)
 		mirrroVirtualChallengeTx := protocols.NewChallengeTransaction(virtualChannelId, signedVirtualState, []state.SignedState{signedPostFundState}, virtualChallengerSig)
-		err = chainServiceA.SendTransaction(mirrroVirtualChallengeTx)
+		err = testChainService.SendTransaction(mirrroVirtualChallengeTx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -734,7 +577,7 @@ func TestExitL2WithVirtualChannelStateUnilaterally(t *testing.T) {
 		// Node A calls modified `challenge` with L2 ledger channel state
 		challengerSig, _ := NitroAdjudicator.SignChallengeMessage(l2SignedState.State(), tcL1.Participants[0].PrivateKey)
 		challengeTx := protocols.NewChallengeTransaction(l1ChannelId, l2SignedState, []state.SignedState{}, challengerSig)
-		err = chainServiceA.SendTransaction(challengeTx)
+		err = testChainService.SendTransaction(challengeTx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -774,7 +617,7 @@ func TestExitL2WithVirtualChannelStateUnilaterally(t *testing.T) {
 		}
 
 		reclaimTx := protocols.NewReclaimTransaction(l1ChannelId, reclaimArgs)
-		err = chainServiceA.SendTransaction(reclaimTx)
+		err = testChainService.SendTransaction(reclaimTx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -815,7 +658,7 @@ func TestExitL2WithVirtualChannelStateUnilaterally(t *testing.T) {
 		signedConstructedState := state.NewSignedState(latestState)
 
 		mirrorTransferAllTx := protocols.NewMirrorTransferAllTransaction(l1ChannelId, signedConstructedState)
-		err = chainServiceA.SendTransaction(mirrorTransferAllTx)
+		err = testChainService.SendTransaction(mirrorTransferAllTx)
 		if err != nil {
 			t.Error(err)
 		}

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -167,7 +167,7 @@ func TestCheckpoint(t *testing.T) {
 
 	// Bob waits for the channel to enter challenge mode and then counters the registered challenge by checkpoint
 	listenForLedgerUpdates(ledgerUpdatesChannelNodeB, channel.Challenge)
-	nodeB.CounterChallenge(ledgerChannel, types.Checkpoint, nil)
+	nodeB.CounterChallenge(ledgerChannel, types.Checkpoint, state.SignedState{})
 
 	// Wait for direct defund objectives to complete
 	chA := nodeA.ObjectiveCompleteChan(res)
@@ -273,7 +273,7 @@ func TestCounterChallenge(t *testing.T) {
 
 	// Bob waits for the channel to enter challenge mode and then counters the registered challenge by raising a new one
 	listenForLedgerUpdates(ledgerUpdatesChannelNodeB, channel.Challenge)
-	nodeB.CounterChallenge(ledgerChannel, types.Challenge, nil)
+	nodeB.CounterChallenge(ledgerChannel, types.Challenge, state.SignedState{})
 
 	// Wait for direct defund objectives to complete
 	chA := nodeA.ObjectiveCompleteChan(res)

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -167,7 +167,7 @@ func TestCheckpoint(t *testing.T) {
 
 	// Bob waits for the channel to enter challenge mode and then counters the registered challenge by checkpoint
 	listenForLedgerUpdates(ledgerUpdatesChannelNodeB, channel.Challenge)
-	nodeB.CounterChallenge(ledgerChannel, types.Checkpoint)
+	nodeB.CounterChallenge(ledgerChannel, types.Checkpoint, nil)
 
 	// Wait for direct defund objectives to complete
 	chA := nodeA.ObjectiveCompleteChan(res)
@@ -273,7 +273,7 @@ func TestCounterChallenge(t *testing.T) {
 
 	// Bob waits for the channel to enter challenge mode and then counters the registered challenge by raising a new one
 	listenForLedgerUpdates(ledgerUpdatesChannelNodeB, channel.Challenge)
-	nodeB.CounterChallenge(ledgerChannel, types.Challenge)
+	nodeB.CounterChallenge(ledgerChannel, types.Challenge, nil)
 
 	// Wait for direct defund objectives to complete
 	chA := nodeA.ObjectiveCompleteChan(res)

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -225,22 +225,39 @@ func closeLedgerChannel(t *testing.T, alpha node.Node, beta node.Node, channelId
 }
 
 func waitForObjectives(t *testing.T, a, b node.Node, intermediaries []node.Node, objectiveIds []protocols.ObjectiveId) {
-	var ObjectivesToWaitFor []<-chan struct{}
+	type CompletedObjective struct {
+		channnel    <-chan struct{}
+		address     common.Address
+		objectiveId protocols.ObjectiveId
+	}
+
+	var ObjectivesToWaitFor []CompletedObjective
 
 	for _, objectiveId := range objectiveIds {
-		chA := a.ObjectiveCompleteChan(objectiveId)
-		ObjectivesToWaitFor = append(ObjectivesToWaitFor, chA)
-		chB := b.ObjectiveCompleteChan(objectiveId)
-		ObjectivesToWaitFor = append(ObjectivesToWaitFor, chB)
+		ObjectivesToWaitFor = append(ObjectivesToWaitFor, CompletedObjective{
+			channnel:    a.ObjectiveCompleteChan(objectiveId),
+			address:     *a.Address,
+			objectiveId: objectiveId,
+		})
+
+		ObjectivesToWaitFor = append(ObjectivesToWaitFor, CompletedObjective{
+			channnel:    b.ObjectiveCompleteChan(objectiveId),
+			address:     *b.Address,
+			objectiveId: objectiveId,
+		})
 
 		for _, intermediary := range intermediaries {
-			chI := intermediary.ObjectiveCompleteChan(objectiveId)
-			ObjectivesToWaitFor = append(ObjectivesToWaitFor, chI)
+			ObjectivesToWaitFor = append(ObjectivesToWaitFor, CompletedObjective{
+				channnel:    intermediary.ObjectiveCompleteChan(objectiveId),
+				address:     *intermediary.Address,
+				objectiveId: objectiveId,
+			})
 		}
 	}
 
-	for _, ch := range ObjectivesToWaitFor {
-		<-ch
+	for _, obj := range ObjectivesToWaitFor {
+		t.Logf("Node %s waiting for objective %s to complete", obj.address.String(), obj.objectiveId)
+		<-obj.channnel
 	}
 }
 

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -233,7 +233,7 @@ export class NitroRpcClient implements RpcClientApi {
     const payload = {
       ChannelId: channelId,
       Action: action,
-      Payload: signedState,
+      StringifiedL2SignedState: signedState,
     };
     return this.sendRequest("counter_challenge", payload);
   }

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -144,7 +144,7 @@ export class NitroRpcClient implements RpcClientApi {
   ): Promise<ObjectiveResponse> {
     const payload: DirectFundPayload = {
       CounterParty: counterParty,
-      ChallengeDuration: 0,
+      ChallengeDuration: 10,
       Outcome: createOutcome(
         assetAddress,
         await this.GetAddress(),

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -227,11 +227,13 @@ export class NitroRpcClient implements RpcClientApi {
 
   public async CounterChallenge(
     channelId: string,
-    action: CounterChallengeAction
+    action: CounterChallengeAction,
+    signedState?: string
   ): Promise<CounterChallengeResult> {
     const payload = {
       ChannelId: channelId,
       Action: action,
+      Payload: signedState,
     };
     return this.sendRequest("counter_challenge", payload);
   }

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -50,6 +50,7 @@ const counterChallengeSchema = {
   properties: {
     ChannelId: { type: "string" },
     Action: { type: "int32" },
+    Payload: { type: "string" },
   },
 } as const;
 type CounterChallengeSchemaType = JTDDataType<typeof counterChallengeSchema>;

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -60,6 +60,7 @@ export enum CounterChallengeAction {
 export type CounterChallengePayload = {
   ChannelId: string;
   Action: CounterChallengeAction;
+  Payload?: string;
 };
 
 export type CounterChallengeResult = {

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -60,7 +60,7 @@ export enum CounterChallengeAction {
 export type CounterChallengePayload = {
   ChannelId: string;
   Action: CounterChallengeAction;
-  Payload?: string;
+  StringifiedL2SignedState?: string;
 };
 
 export type CounterChallengeResult = {

--- a/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
+++ b/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
@@ -158,10 +158,10 @@ func (o *Objective) crankWithChallenge(updated Objective, sideEffects protocols.
 		return &updated, sideEffects, WaitingForNothing, nil
 	}
 
-	if updated.C.OnChain.ChannelMode == channel.Finalized && !updated.mirrorTransactionSubmitted && updated.C.OnChain.IsChallengeInitiatedByMe {
+	if updated.C.OnChain.ChannelMode == channel.Finalized && !updated.MirrorTransactionSubmitted && updated.C.OnChain.IsChallengeInitiatedByMe {
 		// Send MirrorTransferAll transaction
 		mirrorWithdrawAllTx := protocols.NewMirrorTransferAllTransaction(updated.OwnsChannel(), updated.L2SignedState)
-		updated.mirrorTransactionSubmitted = true
+		updated.MirrorTransactionSubmitted = true
 		sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, mirrorWithdrawAllTx)
 		return &updated, sideEffects, WaitingForWithdraw, nil
 	}

--- a/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
+++ b/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
@@ -110,7 +110,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		return &updated, sideEffects, WaitingForNothing, protocols.ErrNotApproved
 	}
 
-	if updated.IsChallenge || updated.IsCheckPoint {
+	if updated.IsChallenge || updated.IsCheckPoint || updated.C.OnChain.ChannelMode != channel.Open {
 		return o.crankWithChallenge(updated, sideEffects, secretKey)
 	}
 
@@ -171,6 +171,7 @@ func (o *Objective) crankWithChallenge(updated Objective, sideEffects protocols.
 		return &updated, sideEffects, WaitingForWithdraw, nil
 	}
 
+	updated.Status = protocols.Completed
 	return &updated, sideEffects, WaitingForNothing, nil
 }
 

--- a/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
+++ b/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
@@ -412,3 +412,49 @@ func (r ObjectiveRequest) WaitForObjectiveToStart() {
 func (r ObjectiveRequest) Id(myAddress types.Address, chainId *big.Int) protocols.ObjectiveId {
 	return protocols.ObjectiveId(ObjectivePrefix + r.l1ChannelId.String())
 }
+
+// CreateConsensusChannelFromChannel creates a ConsensusChannel from the Objective by extracting signatures and a single asset outcome from the latest supported signed state.
+func (o *Objective) CreateConsensusChannelFromChannel() (*consensus_channel.ConsensusChannel, error) {
+	ledger := o.C
+
+	signedState, err := ledger.LatestSupportedSignedState()
+	if err != nil {
+		return nil, fmt.Errorf("could not get latest supported signed state")
+	}
+	leaderSig, err := signedState.GetParticipantSignature(uint(consensus_channel.Leader))
+	if err != nil {
+		return nil, fmt.Errorf("could not get leader signature: %w", err)
+	}
+	followerSig, err := signedState.GetParticipantSignature(uint(consensus_channel.Follower))
+	if err != nil {
+		return nil, fmt.Errorf("could not get follower signature: %w", err)
+	}
+	signatures := [2]state.Signature{leaderSig, followerSig}
+
+	if len(signedState.State().Outcome) != 1 {
+		return nil, fmt.Errorf("a consensus channel only supports a single asset")
+	}
+	assetExit := signedState.State().Outcome[0]
+	turnNum := signedState.State().TurnNum
+	outcome, err := consensus_channel.FromExit(assetExit)
+	if err != nil {
+		return nil, fmt.Errorf("could not create ledger outcome from channel exit: %w", err)
+	}
+
+	if ledger.MyIndex == uint(consensus_channel.Leader) {
+		con, err := consensus_channel.NewLeaderChannel(ledger.FixedPart, turnNum, outcome, signatures)
+		con.OnChainFunding = ledger.OnChain.Holdings.Clone() // Copy OnChain.Holdings so we don't lose this information
+		if err != nil {
+			return nil, fmt.Errorf("could not create consensus channel as leader: %w", err)
+		}
+		return &con, nil
+
+	} else {
+		con, err := consensus_channel.NewFollowerChannel(ledger.FixedPart, turnNum, outcome, signatures)
+		con.OnChainFunding = ledger.OnChain.Holdings.Clone() // Copy OnChain.Holdings so we don't lose this information
+		if err != nil {
+			return nil, fmt.Errorf("could not create consensus channel as follower: %w", err)
+		}
+		return &con, nil
+	}
+}

--- a/protocols/mirrorbridgeddefund/serde.go
+++ b/protocols/mirrorbridgeddefund/serde.go
@@ -17,7 +17,9 @@ type jsonObjective struct {
 	MirrorTransactionSubmitted    bool
 	L2SignedState                 state.SignedState
 	IsChallenge                   bool
+	IsCheckPoint                  bool
 	ChallengeTransactionSubmitted bool
+	CheckPointransactionSubmitted bool
 }
 
 // MarshalJSON returns a JSON representation of the MirrorBridgedDefundObjective
@@ -31,6 +33,8 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 		o.L2SignedState,
 		o.IsChallenge,
 		o.ChallengeTransactionSubmitted,
+		o.IsCheckPoint,
+		o.CheckpointTransactionSubmitted,
 	}
 
 	return json.Marshal(jsonDDFO)
@@ -59,6 +63,8 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.L2SignedState = jsonDDFO.L2SignedState
 	o.IsChallenge = jsonDDFO.IsChallenge
 	o.ChallengeTransactionSubmitted = jsonDDFO.ChallengeTransactionSubmitted
+	o.IsCheckPoint = jsonDDFO.IsCheckPoint
+	o.CheckpointTransactionSubmitted = jsonDDFO.CheckPointransactionSubmitted
 
 	return nil
 }

--- a/protocols/mirrorbridgeddefund/serde.go
+++ b/protocols/mirrorbridgeddefund/serde.go
@@ -17,8 +17,8 @@ type jsonObjective struct {
 	MirrorTransactionSubmitted    bool
 	L2SignedState                 state.SignedState
 	IsChallenge                   bool
-	IsCheckPoint                  bool
 	ChallengeTransactionSubmitted bool
+	IsCheckPoint                  bool
 	CheckPointransactionSubmitted bool
 }
 

--- a/rpc/bridge-server.go
+++ b/rpc/bridge-server.go
@@ -2,11 +2,15 @@ package rpc
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/statechannels/go-nitro/bridge"
+	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/node/query"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/bridgeddefund"
 	"github.com/statechannels/go-nitro/rpc/serde"
 	"github.com/statechannels/go-nitro/rpc/transport"
 )
@@ -67,6 +71,51 @@ func (brs *BridgeRpcServer) registerHandlers() (err error) {
 		case serde.GetAllL2ChannelsRequestMethod:
 			return processRequest(brs.BaseRpcServer, permSign, requestData, func(req serde.NoPayloadRequest) ([]query.LedgerChannelInfo, error) {
 				return brs.bridge.GetAllL2Channels()
+			})
+		case serde.CounterChallengeRequestMethod:
+			return processRequest(brs.BaseRpcServer, permSign, requestData, func(req serde.CounterChallengeRequest) (serde.CounterChallengeRequest, error) {
+				var l2SignedState state.SignedState
+				if len(req.Payload) > 0 {
+					err := json.Unmarshal([]byte(req.Payload), &l2SignedState)
+					if err != nil {
+						return serde.CounterChallengeRequest{}, fmt.Errorf("error in unmarshalling signed state payload %w", err)
+					}
+				}
+
+				brs.bridge.CounterChallenge(req.ChannelId, req.Action, l2SignedState)
+				return req, nil
+			})
+		case serde.GetSignedStateMethod:
+			return processRequest(brs.BaseRpcServer, permRead, requestData, func(req serde.GetSignedStateRequest) (string, error) {
+				if err := serde.ValidateGetSignedStateRequest(req); err != nil {
+					return "", err
+				}
+
+				latestState, err := brs.bridge.GetL2SupportedSignedState(req.Id)
+				if err != nil {
+					return "", err
+				}
+
+				marshalledState, err := json.Marshal(latestState)
+				if err != nil {
+					return "", err
+				}
+
+				return string(marshalledState), nil
+			})
+		case serde.MirrorBridgedDefundRequestMethod:
+			return processRequest(brs.BaseRpcServer, permSign, requestData, func(req serde.MirrorBridgedDefundRequest) (protocols.ObjectiveId, error) {
+				if DISABLE_BRIDGE_DEFUND {
+					return protocols.ObjectiveId(bridgeddefund.ObjectivePrefix + req.ChannelId.String()), fmt.Errorf("brided defund is currently disabled")
+				}
+
+				var l2SignedState state.SignedState
+				err := json.Unmarshal([]byte(req.StringifiedL2SignedState), &l2SignedState)
+				if err != nil {
+					return "", err
+				}
+
+				return brs.bridge.MirrorBridgedDefund(req.ChannelId, l2SignedState, req.IsChallenge)
 			})
 		default:
 			errRes := serde.NewJsonRpcErrorResponse(jsonrpcReq.Id, serde.MethodNotFoundError)

--- a/rpc/bridge-server.go
+++ b/rpc/bridge-server.go
@@ -75,8 +75,8 @@ func (brs *BridgeRpcServer) registerHandlers() (err error) {
 		case serde.CounterChallengeRequestMethod:
 			return processRequest(brs.BaseRpcServer, permSign, requestData, func(req serde.CounterChallengeRequest) (serde.CounterChallengeRequest, error) {
 				var l2SignedState state.SignedState
-				if len(req.Payload) > 0 {
-					err := json.Unmarshal([]byte(req.Payload), &l2SignedState)
+				if len(req.StringifiedL2SignedState) > 0 {
+					err := json.Unmarshal([]byte(req.StringifiedL2SignedState), &l2SignedState)
 					if err != nil {
 						return serde.CounterChallengeRequest{}, fmt.Errorf("error in unmarshalling signed state payload %w", err)
 					}

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -196,7 +196,8 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 			})
 		case serde.CounterChallengeRequestMethod:
 			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.CounterChallengeRequest) (serde.CounterChallengeRequest, error) {
-				nrs.node.CounterChallenge(req.ChannelId, req.Action, nil)
+				// TODO: Unmarshall the signed state string
+				nrs.node.CounterChallenge(req.ChannelId, req.Action, req.Payload)
 				return req, nil
 			})
 		case serde.GetSignedStateMethod:

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -196,8 +196,15 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 			})
 		case serde.CounterChallengeRequestMethod:
 			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.CounterChallengeRequest) (serde.CounterChallengeRequest, error) {
-				// TODO: Unmarshall the signed state string
-				nrs.node.CounterChallenge(req.ChannelId, req.Action, req.Payload)
+				var l2SignedState state.SignedState
+				if len(req.Payload) > 0 {
+					err := json.Unmarshal([]byte(req.Payload), &l2SignedState)
+					if err != nil {
+						return serde.CounterChallengeRequest{}, fmt.Errorf("error in unmarshalling signed state payload %w", err)
+					}
+				}
+
+				nrs.node.CounterChallenge(req.ChannelId, req.Action, l2SignedState)
 				return req, nil
 			})
 		case serde.GetSignedStateMethod:

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -196,7 +196,7 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 			})
 		case serde.CounterChallengeRequestMethod:
 			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.CounterChallengeRequest) (serde.CounterChallengeRequest, error) {
-				nrs.node.CounterChallenge(req.ChannelId, req.Action)
+				nrs.node.CounterChallenge(req.ChannelId, req.Action, nil)
 				return req, nil
 			})
 		case serde.GetSignedStateMethod:

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -197,8 +197,8 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 		case serde.CounterChallengeRequestMethod:
 			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.CounterChallengeRequest) (serde.CounterChallengeRequest, error) {
 				var l2SignedState state.SignedState
-				if len(req.Payload) > 0 {
-					err := json.Unmarshal([]byte(req.Payload), &l2SignedState)
+				if len(req.StringifiedL2SignedState) > 0 {
+					err := json.Unmarshal([]byte(req.StringifiedL2SignedState), &l2SignedState)
 					if err != nil {
 						return serde.CounterChallengeRequest{}, fmt.Errorf("error in unmarshalling signed state payload %w", err)
 					}

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -70,9 +70,9 @@ type MirrorBridgedDefundRequest struct {
 }
 
 type CounterChallengeRequest struct {
-	ChannelId types.Destination
-	Action    types.CounterChallengeAction
-	Payload   string
+	ChannelId                types.Destination
+	Action                   types.CounterChallengeAction
+	StringifiedL2SignedState string
 }
 
 type GetPaymentChannelRequest struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -3,6 +3,7 @@ package serde
 import (
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
@@ -72,6 +73,7 @@ type MirrorBridgedDefundRequest struct {
 type CounterChallengeRequest struct {
 	ChannelId types.Destination
 	Action    types.CounterChallengeAction
+	Payload   state.SignedState
 }
 
 type GetPaymentChannelRequest struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -3,7 +3,6 @@ package serde
 import (
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
@@ -73,7 +72,7 @@ type MirrorBridgedDefundRequest struct {
 type CounterChallengeRequest struct {
 	ChannelId types.Destination
 	Action    types.CounterChallengeAction
-	Payload   state.SignedState
+	Payload   string
 }
 
 type GetPaymentChannelRequest struct {

--- a/types/types.go
+++ b/types/types.go
@@ -39,9 +39,3 @@ const (
 	Checkpoint CounterChallengeAction = iota
 	Challenge
 )
-
-type CounterChallengeRequest struct {
-	ChannelId Destination
-	Action    CounterChallengeAction
-	Payload   interface{}
-}

--- a/types/types.go
+++ b/types/types.go
@@ -43,4 +43,5 @@ const (
 type CounterChallengeRequest struct {
 	ChannelId Destination
 	Action    CounterChallengeAction
+	Payload   interface{}
 }


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Implement checkpoint to clear mirror bridged defund challenge
- Implement counter challenge to counter the registered mirror bridged defund challenge
- Update counter challenge client and server method to accept signed state
- Add test case for counter challenging and checkpointing mirror bridged defund challenge