### PR TITLE
Add CLI method to retry tx of an objective on chain reorgs

### DIFF
--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -802,6 +802,7 @@ func (e *Engine) handleRetryTxRequest(request types.RetryTxRequest) error {
 			return nil
 		}
 
+		// TODO: Only check for safe to deposit
 		if !objective.SafeToDeposit() {
 			return fmt.Errorf("Not safe to deposit right now")
 		}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -798,7 +798,6 @@ func (e *Engine) handleRetryTxRequest(request types.RetryTxRequest) error {
 	// Based on objective type, send appropriate tx
 	switch objective := obj.(type) {
 	case *directfund.Objective:
-
 		objective.ResetTxSubmitted()
 
 		_, err = e.attemptProgress(objective)

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -156,6 +156,7 @@ func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain c
 	e.ObjectiveRequestsFromAPI = make(chan protocols.ObjectiveRequest)
 	e.PaymentRequestsFromAPI = make(chan PaymentRequest)
 	e.CounterChallengeRequestsFromAPI = make(chan CounterChallengeRequest)
+	e.RetryTxRequestFromAPI = make(chan types.RetryTxRequest)
 
 	e.fromChain = chain.EventFeed()
 	e.fromMsg = msg.P2PMessages()

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -109,8 +109,8 @@ func NewMessageService(opts MessageOpts) *P2PMessageService {
 		libp2p.Identity(privateKey),
 		libp2p.AddrsFactory(addressFactory),
 		libp2p.ListenAddrStrings(
-			fmt.Sprintf("/ip4/%s/tcp/%d", opts.PublicIp, opts.TcpPort),
-			fmt.Sprintf("/ip4/%s/tcp/%d/ws", opts.PublicIp, opts.WsMsgPort),
+			fmt.Sprintf("/ip4/%s/tcp/%d", "0.0.0.0", opts.TcpPort),
+			fmt.Sprintf("/ip4/%s/tcp/%d/ws", "0.0.0.0", opts.WsMsgPort),
 		),
 		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.NATPortMap(),

--- a/node/node.go
+++ b/node/node.go
@@ -396,3 +396,7 @@ func (n *Node) handleError(err error) {
 func (n *Node) CounterChallenge(id types.Destination, action types.CounterChallengeAction, payload state.SignedState) {
 	n.engine.CounterChallengeRequestsFromAPI <- engine.CounterChallengeRequest{ChannelId: id, Action: action, Payload: payload}
 }
+
+func (n *Node) RetryTx(objectiveId protocols.ObjectiveId) {
+	n.engine.RetryTxRequestFromAPI <- types.RetryTxRequest{ObjectiveId: string(objectiveId)}
+}

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -236,6 +236,37 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
+    "retry-tx <objectiveId>",
+    "Retries transaction for given objective",
+    (yargsBuilder) => {
+      return yargsBuilder.positional("objectiveId", {
+        describe: "The id of the objective to send transaction for",
+        type: "string",
+        demandOption: true,
+      });
+    },
+
+    async (yargs) => {
+      const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
+      const isSecure = yargs.s;
+
+      const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
+        getRPCUrl(rpcHost, rpcPort),
+        isSecure
+      );
+      await rpcClient.RetryTx(yargs.objectiveId);
+
+      // Not using WaitForLedgerChannelStatus method with complete status, as the ledger channel status will be open if a challenge is cleared using checkpoint
+      await rpcClient.WaitForObjectiveToComplete(
+        `DirectDefunding-${yargs.channelId}`
+      );
+      console.log(`Objective Complete ${yargs.channelId}`);
+      await rpcClient.Close();
+      process.exit(0);
+    }
+  )
+  .command(
     "direct-defund <channelId>",
     "Defunds a directly funded ledger channel",
     (yargsBuilder) => {

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -256,9 +256,9 @@ yargs(hideBin(process.argv))
         isSecure
       );
 
-      const res = await rpcClient.RetryTx(yargs.objectiveId);
+      const id = await rpcClient.RetryTx(yargs.objectiveId);
 
-      console.log(`Transaction retried for objective ${res.ObjectiveId}`);
+      console.log(`Transaction retried for objective ${id}`);
       await rpcClient.Close();
       process.exit(0);
     }

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -255,13 +255,10 @@ yargs(hideBin(process.argv))
         getRPCUrl(rpcHost, rpcPort),
         isSecure
       );
-      await rpcClient.RetryTx(yargs.objectiveId);
 
-      // Not using WaitForLedgerChannelStatus method with complete status, as the ledger channel status will be open if a challenge is cleared using checkpoint
-      await rpcClient.WaitForObjectiveToComplete(
-        `DirectDefunding-${yargs.channelId}`
-      );
-      console.log(`Objective Complete ${yargs.channelId}`);
+      const res = await rpcClient.RetryTx(yargs.objectiveId);
+
+      console.log(`Transaction retried for objective ${res.ObjectiveId}`);
       await rpcClient.Close();
       process.exit(0);
     }

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -18,6 +18,7 @@ import {
   CounterChallengeResult,
   ObjectiveCompleteNotification,
   MirrorBridgedDefundObjectiveRequest,
+  ObjectiveIdResponse,
 } from "./types";
 import { Transport } from "./transport";
 import { createOutcome, generateRequest } from "./utils";
@@ -157,6 +158,10 @@ export class NitroRpcClient implements RpcClientApi {
       Nonce: Date.now(),
     };
     return this.sendRequest("create_ledger_channel", payload);
+  }
+
+  public async RetryTx(objectiveId: string): Promise<ObjectiveIdResponse> {
+    return this.sendRequest("retry_tx", { ObjectiveId: objectiveId });
   }
 
   public async CreatePaymentChannel(

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -18,7 +18,6 @@ import {
   CounterChallengeResult,
   ObjectiveCompleteNotification,
   MirrorBridgedDefundObjectiveRequest,
-  ObjectiveIdResponse,
 } from "./types";
 import { Transport } from "./transport";
 import { createOutcome, generateRequest } from "./utils";
@@ -160,7 +159,7 @@ export class NitroRpcClient implements RpcClientApi {
     return this.sendRequest("create_ledger_channel", payload);
   }
 
-  public async RetryTx(objectiveId: string): Promise<ObjectiveIdResponse> {
+  public async RetryTx(objectiveId: string): Promise<string> {
     return this.sendRequest("retry_tx", { ObjectiveId: objectiveId });
   }
 

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -43,6 +43,13 @@ const objectiveSchema = {
 } as const;
 type ObjectiveSchemaType = JTDDataType<typeof objectiveSchema>;
 
+const objectiveIdSchema = {
+  properties: {
+    ObjectiveId: { type: "string" },
+  },
+} as const;
+type ObjectiveIdSchemaType = JTDDataType<typeof objectiveIdSchema>;
+
 const stringSchema = { type: "string" } as const;
 type StringSchemaType = JTDDataType<typeof stringSchema>;
 
@@ -134,6 +141,7 @@ type ReceiveVoucherSchemaType = JTDDataType<typeof receiveVoucherSchema>;
 
 type ResponseSchema =
   | typeof objectiveSchema
+  | typeof objectiveIdSchema
   | typeof stringSchema
   | typeof ledgerChannelSchema
   | typeof ledgerChannelsSchema
@@ -146,6 +154,7 @@ type ResponseSchema =
 
 type ResponseSchemaType =
   | ObjectiveSchemaType
+  | ObjectiveIdSchemaType
   | StringSchemaType
   | LedgerChannelSchemaType
   | LedgerChannelsSchemaType
@@ -177,6 +186,12 @@ export function getAndValidateResult<T extends RequestMethod>(
         objectiveSchema,
         result,
         (result: ObjectiveSchemaType) => result
+      );
+    case "retry_tx":
+      return validateAndConvertResult(
+        objectiveIdSchema,
+        result,
+        (result: ObjectiveIdSchemaType) => result
       );
     case "get_auth_token":
     case "close_ledger_channel":

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -43,13 +43,6 @@ const objectiveSchema = {
 } as const;
 type ObjectiveSchemaType = JTDDataType<typeof objectiveSchema>;
 
-const objectiveIdSchema = {
-  properties: {
-    ObjectiveId: { type: "string" },
-  },
-} as const;
-type ObjectiveIdSchemaType = JTDDataType<typeof objectiveIdSchema>;
-
 const stringSchema = { type: "string" } as const;
 type StringSchemaType = JTDDataType<typeof stringSchema>;
 
@@ -141,7 +134,6 @@ type ReceiveVoucherSchemaType = JTDDataType<typeof receiveVoucherSchema>;
 
 type ResponseSchema =
   | typeof objectiveSchema
-  | typeof objectiveIdSchema
   | typeof stringSchema
   | typeof ledgerChannelSchema
   | typeof ledgerChannelsSchema
@@ -154,7 +146,6 @@ type ResponseSchema =
 
 type ResponseSchemaType =
   | ObjectiveSchemaType
-  | ObjectiveIdSchemaType
   | StringSchemaType
   | LedgerChannelSchemaType
   | LedgerChannelsSchemaType
@@ -188,11 +179,6 @@ export function getAndValidateResult<T extends RequestMethod>(
         (result: ObjectiveSchemaType) => result
       );
     case "retry_tx":
-      return validateAndConvertResult(
-        objectiveIdSchema,
-        result,
-        (result: ObjectiveIdSchemaType) => result
-      );
     case "get_auth_token":
     case "close_ledger_channel":
     case "close_bridge_channel":

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -96,9 +96,6 @@ export type ObjectiveResponse = {
   Id: string;
   ChannelId: string;
 };
-export type ObjectiveIdResponse = {
-  ObjectiveId: string;
-};
 export type ReceiveVoucherResult = {
   Total: bigint;
   Delta: bigint;
@@ -193,7 +190,7 @@ export type VirtualFundResponse = JsonRpcResponse<ObjectiveResponse>;
 export type VersionResponse = JsonRpcResponse<string>;
 export type GetAddressResponse = JsonRpcResponse<string>;
 export type DirectFundResponse = JsonRpcResponse<ObjectiveResponse>;
-export type RetryTxResponse = JsonRpcResponse<ObjectiveIdResponse>;
+export type RetryTxResponse = JsonRpcResponse<string>;
 export type DirectDefundResponse = JsonRpcResponse<string>;
 export type MirrorBridgedDefundResponse = JsonRpcResponse<string>;
 export type BridgedDefundResponse = JsonRpcResponse<string>;

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -96,6 +96,9 @@ export type ObjectiveResponse = {
   Id: string;
   ChannelId: string;
 };
+export type ObjectiveIdResponse = {
+  ObjectiveId: string;
+};
 export type ReceiveVoucherResult = {
   Total: bigint;
   Delta: bigint;
@@ -115,6 +118,12 @@ export type GetAddressRequest = JsonRpcRequest<
 export type DirectFundRequest = JsonRpcRequest<
   "create_ledger_channel",
   DirectFundPayload
+>;
+export type RetryTxRequest = JsonRpcRequest<
+  "retry_tx",
+  {
+    ObjectiveId: string;
+  }
 >;
 export type PaymentRequest = JsonRpcRequest<"pay", PaymentPayload>;
 export type CounterChallengeRequest = JsonRpcRequest<
@@ -184,6 +193,7 @@ export type VirtualFundResponse = JsonRpcResponse<ObjectiveResponse>;
 export type VersionResponse = JsonRpcResponse<string>;
 export type GetAddressResponse = JsonRpcResponse<string>;
 export type DirectFundResponse = JsonRpcResponse<ObjectiveResponse>;
+export type RetryTxResponse = JsonRpcResponse<ObjectiveIdResponse>;
 export type DirectDefundResponse = JsonRpcResponse<string>;
 export type MirrorBridgedDefundResponse = JsonRpcResponse<string>;
 export type BridgedDefundResponse = JsonRpcResponse<string>;
@@ -202,6 +212,7 @@ export type ReceiveVoucherResponse = JsonRpcResponse<ReceiveVoucherResult>;
 export type RPCRequestAndResponses = {
   get_auth_token: [GetAuthTokenRequest, GetAuthTokenResponse];
   create_ledger_channel: [DirectFundRequest, DirectFundResponse];
+  retry_tx: [RetryTxRequest, RetryTxResponse];
   close_ledger_channel: [DirectDefundRequest, DirectDefundResponse];
   close_bridge_channel: [BridgedDefundRequest, BridgedDefundResponse];
   mirror_bridged_defund: [

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -680,3 +680,7 @@ func (o *Objective) CreateConsensusChannelFromChannel() (*consensus_channel.Cons
 		return &con, nil
 	}
 }
+
+func (o *Objective) ResetWithDrawAllTxSubmitted() {
+	o.withdrawTransactionSubmitted = false
+}

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -313,9 +313,9 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	}
 
 	// Funding
-	fundingComplete := updated.fundingComplete() // note all information stored in state (since there are no real events)
-	amountToDeposit := updated.amountToDeposit()
-	safeToDeposit := updated.safeToDeposit()
+	fundingComplete := updated.FundingComplete() // note all information stored in state (since there are no real events)
+	amountToDeposit := updated.AmountToDeposit()
+	safeToDeposit := updated.SafeToDeposit()
 
 	if !fundingComplete && !safeToDeposit {
 		return &updated, sideEffects, WaitingForMyTurnToFund, nil
@@ -360,8 +360,8 @@ func (o *Objective) Related() []protocols.Storable {
 
 //  Private methods on the DirectFundingObjectiveState
 
-// fundingComplete returns true if the recorded OnChainHoldings are greater than or equal to the threshold for being fully funded.
-func (o *Objective) fundingComplete() bool {
+// FundingComplete returns true if the recorded OnChainHoldings are greater than or equal to the threshold for being fully funded.
+func (o *Objective) FundingComplete() bool {
 	for asset, threshold := range o.fullyFundedThreshold {
 		chainHolding, ok := o.C.OnChain.Holdings[asset]
 
@@ -377,8 +377,8 @@ func (o *Objective) fundingComplete() bool {
 	return true
 }
 
-// safeToDeposit returns true if the recorded OnChainHoldings are greater than or equal to the threshold for safety.
-func (o *Objective) safeToDeposit() bool {
+// SafeToDeposit returns true if the recorded OnChainHoldings are greater than or equal to the threshold for safety.
+func (o *Objective) SafeToDeposit() bool {
 	for asset, safetyThreshold := range o.myDepositSafetyThreshold {
 
 		chainHolding, ok := o.C.OnChain.Holdings[asset]
@@ -395,8 +395,8 @@ func (o *Objective) safeToDeposit() bool {
 	return true
 }
 
-// amountToDeposit computes the appropriate amount to deposit given the current recorded OnChainHoldings
-func (o *Objective) amountToDeposit() types.Funds {
+// AmountToDeposit computes the appropriate amount to deposit given the current recorded OnChainHoldings
+func (o *Objective) AmountToDeposit() types.Funds {
 	deposits := make(types.Funds, len(o.C.OnChain.Holdings))
 
 	for asset, target := range o.myDepositTarget {

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -313,9 +313,9 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	}
 
 	// Funding
-	fundingComplete := updated.FundingComplete() // note all information stored in state (since there are no real events)
-	amountToDeposit := updated.AmountToDeposit()
-	safeToDeposit := updated.SafeToDeposit()
+	fundingComplete := updated.fundingComplete() // note all information stored in state (since there are no real events)
+	amountToDeposit := updated.amountToDeposit()
+	safeToDeposit := updated.safeToDeposit()
 
 	if !fundingComplete && !safeToDeposit {
 		return &updated, sideEffects, WaitingForMyTurnToFund, nil
@@ -360,8 +360,8 @@ func (o *Objective) Related() []protocols.Storable {
 
 //  Private methods on the DirectFundingObjectiveState
 
-// FundingComplete returns true if the recorded OnChainHoldings are greater than or equal to the threshold for being fully funded.
-func (o *Objective) FundingComplete() bool {
+// fundingComplete returns true if the recorded OnChainHoldings are greater than or equal to the threshold for being fully funded.
+func (o *Objective) fundingComplete() bool {
 	for asset, threshold := range o.fullyFundedThreshold {
 		chainHolding, ok := o.C.OnChain.Holdings[asset]
 
@@ -377,8 +377,8 @@ func (o *Objective) FundingComplete() bool {
 	return true
 }
 
-// SafeToDeposit returns true if the recorded OnChainHoldings are greater than or equal to the threshold for safety.
-func (o *Objective) SafeToDeposit() bool {
+// safeToDeposit returns true if the recorded OnChainHoldings are greater than or equal to the threshold for safety.
+func (o *Objective) safeToDeposit() bool {
 	for asset, safetyThreshold := range o.myDepositSafetyThreshold {
 
 		chainHolding, ok := o.C.OnChain.Holdings[asset]
@@ -395,8 +395,8 @@ func (o *Objective) SafeToDeposit() bool {
 	return true
 }
 
-// AmountToDeposit computes the appropriate amount to deposit given the current recorded OnChainHoldings
-func (o *Objective) AmountToDeposit() types.Funds {
+// amountToDeposit computes the appropriate amount to deposit given the current recorded OnChainHoldings
+func (o *Objective) amountToDeposit() types.Funds {
 	deposits := make(types.Funds, len(o.C.OnChain.Holdings))
 
 	for asset, target := range o.myDepositTarget {
@@ -428,6 +428,10 @@ func (o *Objective) clone() Objective {
 // IsDirectFundObjective inspects a objective id and returns true if the objective id is for a direct fund objective.
 func IsDirectFundObjective(id protocols.ObjectiveId) bool {
 	return strings.HasPrefix(string(id), ObjectivePrefix)
+}
+
+func (o *Objective) ResetTxSubmitted() {
+	o.transactionSubmitted = false
 }
 
 // ObjectiveRequest represents a request to create a new direct funding objective.

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -234,6 +234,11 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 
 				return string(marshalledState), nil
 			})
+		case serde.RetryTxMethod:
+			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.RetryTxRequest) (serde.RetryTxRequest, error) {
+				nrs.node.RetryTx(req.ObjectiveId)
+				return req, nil
+			})
 		default:
 			errRes := serde.NewJsonRpcErrorResponse(jsonrpcReq.Id, serde.MethodNotFoundError)
 			return marshalResponse(errRes)

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -235,9 +235,9 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 				return string(marshalledState), nil
 			})
 		case serde.RetryTxMethod:
-			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.RetryTxRequest) (serde.RetryTxRequest, error) {
+			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.RetryTxRequest) (protocols.ObjectiveId, error) {
 				nrs.node.RetryTx(req.ObjectiveId)
-				return req, nil
+				return req.ObjectiveId, nil
 			})
 		default:
 			errRes := serde.NewJsonRpcErrorResponse(jsonrpcReq.Id, serde.MethodNotFoundError)

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -168,8 +168,7 @@ type ResponsePayload interface {
 		string |
 		payments.ReceiveVoucherSummary |
 		CounterChallengeRequest |
-		ValidateVoucherResponse |
-		RetryTxRequest
+		ValidateVoucherResponse
 }
 
 type JsonRpcSuccessResponse[T ResponsePayload] struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -40,6 +40,9 @@ const (
 	GetAllL2ChannelsRequestMethod RequestMethod = "get_all_l2_channels"
 
 	GetSignedStateMethod RequestMethod = "get_signed_state"
+
+	// Chain reorgs workaround methods
+	RetryTxMethod RequestMethod = "retry_tx"
 )
 
 type NotificationMethod string
@@ -91,6 +94,9 @@ type ValidateVoucherRequest struct {
 	Signer      common.Address
 	Value       uint64
 }
+type RetryTxRequest struct {
+	ObjectiveId protocols.ObjectiveId
+}
 
 type (
 	NoPayloadRequest = struct{}
@@ -116,7 +122,8 @@ type RequestPayload interface {
 		payments.Voucher |
 		CounterChallengeRequest |
 		ValidateVoucherRequest |
-		bridgeddefund.ObjectiveRequest
+		bridgeddefund.ObjectiveRequest |
+		RetryTxRequest
 }
 
 type NotificationPayload interface {
@@ -161,7 +168,8 @@ type ResponsePayload interface {
 		string |
 		payments.ReceiveVoucherSummary |
 		CounterChallengeRequest |
-		ValidateVoucherResponse
+		ValidateVoucherResponse |
+		RetryTxRequest
 }
 
 type JsonRpcSuccessResponse[T ResponsePayload] struct {

--- a/types/types.go
+++ b/types/types.go
@@ -39,3 +39,7 @@ const (
 	Checkpoint CounterChallengeAction = iota
 	Challenge
 )
+
+type RetryTxRequest struct {
+	ObjectiveId string
+}


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Add CLI to retry tx based on objective id
- Refactor code to handle Approve tx
- Bind P2P message service to all IP addresses