### PR TITLE
Add permissive policy for bridge L1 node to reject direct defund objective

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -136,7 +136,7 @@ func (b *Bridge) Start(configOpts BridgeConfig) (nodeL1 *node.Node, nodeL2 *node
 	}
 
 	// Initialize nodes
-	nodeL1, storeL1, msgServiceL1, chainServiceL1, err := nodeutils.InitializeNode(chainOptsL1, storeOptsL1, messageOptsL1)
+	nodeL1, storeL1, msgServiceL1, chainServiceL1, err := nodeutils.InitializeNode(chainOptsL1, storeOptsL1, messageOptsL1, &NodeL1PermissivePolicy{})
 	if err != nil {
 		return nil, nil, nodeL1MultiAddress, nodeL2MultiAddress, err
 	}

--- a/bridge/policy_maker.go
+++ b/bridge/policy_maker.go
@@ -1,0 +1,19 @@
+package bridge
+
+import (
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/directdefund"
+	"github.com/statechannels/go-nitro/protocols/virtualdefund"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
+)
+
+type NodeL1PermissivePolicy struct{}
+
+func (pp *NodeL1PermissivePolicy) ShouldApprove(o protocols.Objective) bool {
+	// L1 node rejects objectives if they involve virtual funding, virtual defunding, or direct defunding
+	if virtualfund.IsVirtualFundObjective(o.Id()) || virtualdefund.IsVirtualDefundObjective(o.Id()) || directdefund.IsDirectDefundObjective(o.Id()) {
+		return false
+	}
+
+	return o.GetStatus() == protocols.Unapproved
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -11,7 +11,7 @@ import (
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 )
 
-func InitializeNode(chainOpts chainservice.ChainOpts, storeOpts store.StoreOpts, messageOpts p2pms.MessageOpts) (*node.Node, *store.Store, *p2pms.P2PMessageService, chainservice.ChainService, error) {
+func InitializeNode(chainOpts chainservice.ChainOpts, storeOpts store.StoreOpts, messageOpts p2pms.MessageOpts, policymaker engine.PolicyMaker) (*node.Node, *store.Store, *p2pms.P2PMessageService, chainservice.ChainService, error) {
 	ourStore, err := store.NewStore(storeOpts)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -41,7 +41,7 @@ func InitializeNode(chainOpts chainservice.ChainOpts, storeOpts store.StoreOpts,
 		messageService,
 		ourChain,
 		ourStore,
-		&engine.PermissivePolicy{},
+		policymaker,
 	)
 
 	return &node, &ourStore, messageService, ourChain, nil

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	nodeUtils "github.com/statechannels/go-nitro/internal/node"
 	"github.com/statechannels/go-nitro/internal/rpc"
 	"github.com/statechannels/go-nitro/node"
+	"github.com/statechannels/go-nitro/node/engine"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/node/engine/store"
@@ -291,7 +292,7 @@ func main() {
 					CaAddress:          common.HexToAddress(caAddress),
 				}
 
-				node, _, _, _, err = nodeUtils.InitializeNode(chainOpts, storeOpts, messageOpts)
+				node, _, _, _, err = nodeUtils.InitializeNode(chainOpts, storeOpts, messageOpts, &engine.PermissivePolicy{})
 			}
 
 			logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)

- Reject following objectives in bridge L1 node
  - Direct defund
  - Virtual fund
  - Virtual defund
