### PR TITLE
Add CLI to get voucher using payment channel ID

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -337,6 +337,17 @@ func (n *Node) GetPaymentChannelsByLedger(ledgerId types.Destination) ([]query.P
 	return query.GetPaymentChannelsByLedger(ledgerId, n.store, n.vm)
 }
 
+func (n *Node) GetVoucher(id types.Destination) payments.Voucher {
+	var voucher payments.Voucher
+	voucherInfo, voucherFound := n.vm.GetVoucherIfAmountPresent(id)
+
+	if voucherFound {
+		voucher = voucherInfo.LargestVoucher
+	}
+
+	return voucher
+}
+
 // GetAllLedgerChannels returns all ledger channels.
 func (n *Node) GetAllLedgerChannels() ([]query.LedgerChannelInfo, error) {
 	return query.GetAllLedgerChannels(n.store, n.engine.GetConsensusAppAddress())

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -8,7 +8,12 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 
 import { NitroRpcClient } from "./rpc-client";
-import { compactJson, getRPCUrl, logOutChannelUpdates } from "./utils";
+import {
+  compactJson,
+  getRPCUrl,
+  logOutChannelUpdates,
+  prettyJsonBig,
+} from "./utils";
 import { CounterChallengeAction } from "./types";
 import { ZERO_ETHEREUM_ADDRESS } from "./constants";
 
@@ -108,9 +113,7 @@ yargs(hideBin(process.argv))
         isSecure
       );
       const ledgers = await rpcClient.GetAllL2Channels();
-      for (const ledger of ledgers) {
-        console.log(`${compactJson(ledger)}`);
-      }
+      console.log(prettyJsonBig(ledgers));
       await rpcClient.Close();
       process.exit(0);
     }

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -10,9 +10,9 @@ import { hideBin } from "yargs/helpers";
 import { NitroRpcClient } from "./rpc-client";
 import {
   compactJson,
+  prettyJson,
   getRPCUrl,
   logOutChannelUpdates,
-  prettyJsonBig,
 } from "./utils";
 import { CounterChallengeAction } from "./types";
 import { ZERO_ETHEREUM_ADDRESS } from "./constants";
@@ -92,9 +92,7 @@ yargs(hideBin(process.argv))
         isSecure
       );
       const ledgers = await rpcClient.GetAllLedgerChannels();
-      for (const ledger of ledgers) {
-        console.log(`${compactJson(ledger)}`);
-      }
+      console.log(prettyJson(ledgers));
       await rpcClient.Close();
       process.exit(0);
     }
@@ -113,7 +111,7 @@ yargs(hideBin(process.argv))
         isSecure
       );
       const ledgers = await rpcClient.GetAllL2Channels();
-      console.log(prettyJsonBig(ledgers));
+      console.log(prettyJson(ledgers));
       await rpcClient.Close();
       process.exit(0);
     }

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -633,6 +633,32 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
+    "get-voucher <channelId>",
+    "Get largest voucher paid/received on the payment channel",
+    (yargsBuilder) => {
+      return yargsBuilder.positional("channelId", {
+        describe: "The channel ID of the payment channel",
+        type: "string",
+        demandOption: true,
+      });
+    },
+    async (yargs) => {
+      const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
+      const isSecure = yargs.s;
+
+      const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
+        getRPCUrl(rpcHost, rpcPort),
+        isSecure
+      );
+
+      const voucher = await rpcClient.GetVoucher(yargs.channelId);
+      console.log(voucher);
+      await rpcClient.Close();
+      process.exit(0);
+    }
+  )
+  .command(
     "counter-challenge <channelId> <action>",
     "Counter challenge the registered challenge",
     (yargsBuilder) => {

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -199,6 +199,13 @@ export class NitroRpcClient implements RpcClientApi {
     return getAndValidateResult(res, "pay");
   }
 
+  public async GetVoucher(channelId: string): Promise<Voucher> {
+    const payload = {
+      Id: channelId,
+    };
+    return this.sendRequest("get_voucher", payload);
+  }
+
   public async CloseLedgerChannel(
     channelId: string,
     isChallenge: boolean

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -115,7 +115,7 @@ type PaymentSchemaType = JTDDataType<typeof paymentSchema>;
 const voucherSchema = {
   properties: {
     ChannelId: { type: "string" },
-    Amount: { type: "uint32" },
+    Amount: { type: "uint32", nullable: true },
     Signature: {
       type: "string",
     },
@@ -245,15 +245,17 @@ export function getAndValidateResult<T extends RequestMethod>(
           Delta: BigInt(result.Delta),
         })
       );
+
+    case "get_voucher":
     case "create_voucher":
       return validateAndConvertResult(
         voucherSchema,
         result,
-        (result: VoucherSchemaType) => {
-          return {
-            ...result,
-          };
-        }
+        (result: VoucherSchemaType) => ({
+          Amount: result.Amount ?? 0,
+          ChannelId: result.ChannelId,
+          Signature: result.Signature,
+        })
       );
 
     default:

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -148,6 +148,10 @@ export type GetPaymentChannelRequest = JsonRpcRequest<
   "get_payment_channel",
   GetChannelRequest
 >;
+export type GetVoucherRequest = JsonRpcRequest<
+  "get_voucher",
+  GetChannelRequest
+>;
 export type GetPaymentChannelsByLedgerRequest = JsonRpcRequest<
   "get_payment_channels_by_ledger",
   GetByLedgerRequest
@@ -198,6 +202,7 @@ export type ReceiveVoucherRequest = JsonRpcRequest<"receive_voucher", Voucher>;
  */
 export type GetAuthTokenResponse = JsonRpcResponse<string>;
 export type GetPaymentChannelResponse = JsonRpcResponse<PaymentChannelInfo>;
+export type GetVoucherResponse = JsonRpcResponse<Voucher>;
 export type PaymentResponse = JsonRpcResponse<PaymentPayload>;
 export type CounterChallengeResponse = JsonRpcResponse<CounterChallengeResult>;
 export type GetLedgerChannelResponse = JsonRpcResponse<LedgerChannelInfo>;
@@ -238,6 +243,7 @@ export type RPCRequestAndResponses = {
   get_address: [GetAddressRequest, GetAddressResponse];
   get_ledger_channel: [GetLedgerChannelRequest, GetLedgerChannelResponse];
   get_payment_channel: [GetPaymentChannelRequest, GetPaymentChannelResponse];
+  get_voucher: [GetVoucherRequest, GetVoucherResponse];
   pay: [PaymentRequest, PaymentResponse];
   counter_challenge: [CounterChallengeRequest, CounterChallengeResponse];
   close_payment_channel: [VirtualDefundRequest, VirtualDefundResponse];

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -122,3 +122,7 @@ function prettyJson(obj: unknown): string {
 export function compactJson(obj: unknown): string {
   return JSONbig.stringify(obj, null, 0);
 }
+
+export function prettyJsonBig(obj: unknown): string {
+  return JSONbig.stringify(obj, null, 2);
+}

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -116,13 +116,10 @@ export async function logOutChannelUpdates(rpcClient: NitroRpcClient) {
   );
 }
 
-function prettyJson(obj: unknown): string {
-  return JSON.stringify(obj, null, 2);
-}
-export function compactJson(obj: unknown): string {
-  return JSONbig.stringify(obj, null, 0);
+export function prettyJson(obj: unknown): string {
+  return JSONbig.stringify(obj, null, 2);
 }
 
-export function prettyJsonBig(obj: unknown): string {
-  return JSONbig.stringify(obj, null, 2);
+export function compactJson(obj: unknown): string {
+  return JSONbig.stringify(obj, null, 0);
 }

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -66,12 +66,11 @@ func (vm *VoucherManager) Pay(channelId types.Destination, amount *big.Int, pk [
 	newAmount := big.NewInt(0).Add(vInfo.LargestVoucher.Amount, amount)
 	voucher := Voucher{Amount: big.NewInt(0).Set(newAmount), ChannelId: channelId}
 
-	vInfo.LargestVoucher = voucher
-
 	if err := voucher.Sign(pk); err != nil {
 		return voucher, err
 	}
 
+	vInfo.LargestVoucher = voucher
 	err = vm.store.SetVoucherInfo(channelId, *vInfo)
 	if err != nil {
 		return Voucher{}, err

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -197,6 +197,10 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 				}
 				return nrs.node.GetPaymentChannelsByLedger(req.LedgerId)
 			})
+		case serde.GetVoucherRequestMethod:
+			return processRequest(nrs.BaseRpcServer, permRead, requestData, func(req serde.GetVoucherRequest) (payments.Voucher, error) {
+				return nrs.node.GetVoucher(req.Id), nil
+			})
 		case serde.CounterChallengeRequestMethod:
 			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.CounterChallengeRequest) (serde.CounterChallengeRequest, error) {
 				var l2SignedState state.SignedState

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -28,6 +28,7 @@ const (
 	ClosePaymentChannelRequestMethod  RequestMethod = "close_payment_channel"
 	PayRequestMethod                  RequestMethod = "pay"
 	GetPaymentChannelRequestMethod    RequestMethod = "get_payment_channel"
+	GetVoucherRequestMethod           RequestMethod = "get_voucher"
 	GetLedgerChannelRequestMethod     RequestMethod = "get_ledger_channel"
 	GetPaymentChannelsByLedgerMethod  RequestMethod = "get_payment_channels_by_ledger"
 	GetAllLedgerChannelsMethod        RequestMethod = "get_all_ledger_channels"
@@ -84,6 +85,9 @@ type CounterChallengeRequest struct {
 type GetPaymentChannelRequest struct {
 	Id types.Destination
 }
+type GetVoucherRequest struct {
+	Id types.Destination
+}
 type GetLedgerChannelRequest struct {
 	Id types.Destination
 }
@@ -129,6 +133,7 @@ type RequestPayload interface {
 		GetPaymentChannelRequest |
 		GetPaymentChannelsByLedgerRequest |
 		GetSignedStateRequest |
+		GetVoucherRequest |
 		NoPayloadRequest |
 		payments.Voucher |
 		CounterChallengeRequest |


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Add rpc-client and server method to get largest voucher paid/received on payment channel
- Format result of `get-all-l2-channels` CLI