### PR TITLE
Use custom token in challenge and bridge tests

### DIFF
--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
-	Token "github.com/statechannels/go-nitro/node/engine/chainservice/erc20"
 	chainutils "github.com/statechannels/go-nitro/node/engine/chainservice/utils"
 )
 
@@ -25,22 +24,4 @@ func DeployContracts(ctx context.Context, chainUrl, chainAuthToken, chainPk stri
 		return chainutils.ContractAddresses{}, err
 	}
 	return chainutils.DeployContracts(ctx, ethClient, txSubmitter)
-}
-
-// DeployL2Contract deploys bridge contract.
-func DeployL2Contract(ctx context.Context, chainUrl, chainAuthToken, chainPk string) (common.Address, error) {
-	ethClient, txSubmitter, err := chainutils.ConnectToChain(context.Background(), chainUrl, chainAuthToken, common.Hex2Bytes(chainPk))
-	if err != nil {
-		return common.Address{}, err
-	}
-	return chainutils.DeployL2Contract(ctx, ethClient, txSubmitter)
-}
-
-func DeployAndTransferToken(ctx context.Context, chainUrl, chainAuthToken, chainPk string, transferTo []common.Address) (common.Address, *Token.Token, error) {
-	ethClient, txSubmitter, err := chainutils.ConnectToChain(context.Background(), chainUrl, chainAuthToken, common.Hex2Bytes(chainPk))
-	if err != nil {
-		return common.Address{}, nil, err
-	}
-
-	return chainutils.DeployAndTransferToken(ethClient, txSubmitter, transferTo)
 }

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
+	Token "github.com/statechannels/go-nitro/node/engine/chainservice/erc20"
 	chainutils "github.com/statechannels/go-nitro/node/engine/chainservice/utils"
 )
 
@@ -33,4 +34,13 @@ func DeployL2Contract(ctx context.Context, chainUrl, chainAuthToken, chainPk str
 		return common.Address{}, err
 	}
 	return chainutils.DeployL2Contract(ctx, ethClient, txSubmitter)
+}
+
+func DeployAndTransferToken(ctx context.Context, chainUrl, chainAuthToken, chainPk string, transferTo []common.Address) (common.Address, *Token.Token, error) {
+	ethClient, txSubmitter, err := chainutils.ConnectToChain(context.Background(), chainUrl, chainAuthToken, common.Hex2Bytes(chainPk))
+	if err != nil {
+		return common.Address{}, nil, err
+	}
+
+	return chainutils.DeployAndTransferToken(ethClient, txSubmitter, transferTo)
 }

--- a/node/engine/chainservice/utils/utils.go
+++ b/node/engine/chainservice/utils/utils.go
@@ -90,10 +90,10 @@ func DeployContracts(ctx context.Context, ethClient *ethclient.Client, txSubmitt
 	}, nil
 }
 
-func TransferToken(ethClient *ethclient.Client, tokenBinding *Token.Token, txSubmitter *bind.TransactOpts, transferAccounts []string, initialTokenBalance int64) error {
-	for _, chainPk := range transferAccounts {
-		account := crypto.GetAddressFromSecretKeyBytes(common.Hex2Bytes(chainPk))
-		_, err := tokenBinding.Transfer(txSubmitter, account, big.NewInt(initialTokenBalance))
+func TransferToken(ethClient *ethclient.Client, tokenBinding *Token.Token, txSubmitter *bind.TransactOpts, recipientAccountPks []string, initialTokenBalance int64) error {
+	for _, chainPk := range recipientAccountPks {
+		accountAddress := crypto.GetAddressFromSecretKeyBytes(common.Hex2Bytes(chainPk))
+		_, err := tokenBinding.Transfer(txSubmitter, accountAddress, big.NewInt(initialTokenBalance))
 		if err != nil {
 			return err
 		}

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -1,7 +1,6 @@
 package node_test
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -870,9 +869,6 @@ func initializeUtilsWithBridge(t *testing.T, closeBridge bool) (UtilsWithBridge,
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(">>>>>>>l1 l2 token ", infraL1.anvilChain.ContractAddresses.TokenAddress, infraL2.anvilChain.ContractAddresses.TokenAddress)
-
-	fmt.Println(">>>>>>>infraL2.anvilChain.EthClient ", infraL1.anvilChain.EthClient, infraL2.anvilChain.EthClient)
 
 	bridgeConfig := bridge.BridgeConfig{
 		L1ChainUrl:        infraL1.anvilChain.ChainUrl,

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -1,6 +1,7 @@
 package node_test
 
 import (
+	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -11,11 +12,14 @@ import (
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/internal/chain"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	NitroAdjudicator "github.com/statechannels/go-nitro/node/engine/chainservice/adjudicator"
+	Token "github.com/statechannels/go-nitro/node/engine/chainservice/erc20"
+
 	"github.com/statechannels/go-nitro/node/engine/store"
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/protocols"
@@ -44,6 +48,8 @@ type UtilsWithBridge struct {
 	chainServiceA, chainServiceAPrime          chainservice.ChainService
 	storeA, storeAPrime                        store.Store
 	infraL1, infraL2                           sharedTestInfrastructure
+	l1TokenAddress, l2TokenAddress             common.Address
+	l1TokenBinding, l2TokenBinding             *Token.Token
 }
 
 func TestBridgedFund(t *testing.T) {
@@ -54,14 +60,13 @@ func TestBridgedFund(t *testing.T) {
 	nodeA, nodeAPrime := utils.nodeA, utils.nodeAPrime
 	bridge, bridgeAddress := utils.bridge, utils.bridgeAddress
 	storeA := utils.storeA
-	infraL1 := utils.infraL1
 
 	var l1LedgerChannelId types.Destination
 	var l2LedgerChannelId types.Destination
 
 	t.Run("Create ledger channel on L1 and mirror it on L2", func(t *testing.T) {
 		// Alice create ledger channel with bridge
-		outcome := CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, types.Address{})
+		outcome := CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, utils.l1TokenAddress)
 		l1LedgerChannelResponse, err := nodeA.CreateLedgerChannel(bridgeAddress, uint32(tcL1.ChallengeDuration), outcome)
 		if err != nil {
 			t.Fatal(err)
@@ -75,8 +80,8 @@ func TestBridgedFund(t *testing.T) {
 		completedMirrorChannel := <-bridge.CompletedMirrorChannels()
 		l2LedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
 		testhelpers.Assert(t, completedMirrorChannel == l2LedgerChannelId, "Expects mirror channel id to be %v", l2LedgerChannelId)
-		checkLedgerChannel(t, l1LedgerChannelResponse.ChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, types.Address{}), query.Open, nodeA)
-		checkLedgerChannel(t, l2LedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeAPrime.Address, 0, ledgerChannelDeposit, types.Address{}), query.Open, nodeAPrime)
+		checkLedgerChannel(t, l1LedgerChannelResponse.ChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, utils.l1TokenAddress), query.Open, nodeA)
+		checkLedgerChannel(t, l2LedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeAPrime.Address, 0, ledgerChannelDeposit, utils.l2TokenAddress), query.Open, nodeAPrime)
 	})
 
 	t.Run("Create virtual channel on mirrored ledger channel and make payments", func(t *testing.T) {
@@ -127,10 +132,11 @@ func TestBridgedFund(t *testing.T) {
 			}
 		}
 
-		checkLedgerChannel(t, l1LedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, payAmount, types.Address{}), query.Complete, nodeA)
+		// TODO: Fix asset address mismatch in get ledger channel query after mirror bridged defund
+		checkLedgerChannel(t, l1LedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, payAmount, utils.l2TokenAddress), query.Complete, nodeA)
 
-		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
-		balanceBridge, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())
+		balanceNodeA, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[0].Address())
+		balanceBridge, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[1].Address())
 		t.Logf("Balance of node A %v \nBalance of Bridge %v", balanceNodeA, balanceBridge)
 
 		// NodeA's balance is determined by subtracting amount paid from it's ledger deposit, while Bridge's balance is calculated by adding the amount received
@@ -147,9 +153,8 @@ func TestBridgedFundWithCheckpoint(t *testing.T) {
 	nodeA, nodeAPrime := utils.nodeA, utils.nodeAPrime
 	bridge, bridgeAddress := utils.bridge, utils.bridgeAddress
 	storeA, storeAPrime := utils.storeA, utils.storeAPrime
-	infraL1 := utils.infraL1
 
-	l1LedgerChannelId, l2LedgerChannelId := createMirrorChannel(t, nodeA, bridge, tcL1.ChallengeDuration)
+	l1LedgerChannelId, l2LedgerChannelId := createMirrorChannel(t, nodeA, bridge, tcL1.ChallengeDuration, utils.l1TokenAddress)
 
 	cc, err := storeAPrime.GetConsensusChannelById(l2LedgerChannelId)
 	if err != nil {
@@ -201,8 +206,8 @@ func TestBridgedFundWithCheckpoint(t *testing.T) {
 		}
 		testhelpers.Assert(t, objective.OwnsChannel() == l1LedgerChannelId, "Expects L1 ledger channel Id to be %v", l1LedgerChannelId)
 
-		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
-		balanceBridge, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())
+		balanceNodeA, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[0].Address())
+		balanceBridge, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[1].Address())
 		t.Logf("Balance of node A %v \nBalance of Bridge %v", balanceNodeA, balanceBridge)
 
 		// NodeA's balance is determined by subtracting amount paid from it's ledger deposit, while Bridge's balance is calculated by adding the amount received
@@ -219,9 +224,8 @@ func TestBridgedFundWithCounterChallenge(t *testing.T) {
 	nodeA, nodeAPrime := utils.nodeA, utils.nodeAPrime
 	bridge, bridgeAddress := utils.bridge, utils.bridgeAddress
 	storeA, storeAPrime := utils.storeA, utils.storeAPrime
-	infraL1 := utils.infraL1
 
-	l1LedgerChannelId, l2LedgerChannelId := createMirrorChannel(t, nodeA, bridge, tcL1.ChallengeDuration)
+	l1LedgerChannelId, l2LedgerChannelId := createMirrorChannel(t, nodeA, bridge, tcL1.ChallengeDuration, utils.l1TokenAddress)
 
 	cc, err := storeAPrime.GetConsensusChannelById(l2LedgerChannelId)
 	if err != nil {
@@ -261,8 +265,8 @@ func TestBridgedFundWithCounterChallenge(t *testing.T) {
 		}
 		testhelpers.Assert(t, objective.OwnsChannel() == l1LedgerChannelId, "Expects L1 ledger channel Id to be %v", l1LedgerChannelId)
 
-		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
-		balanceBridge, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())
+		balanceNodeA, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[0].Address())
+		balanceBridge, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[1].Address())
 		t.Logf("Balance of node A %v \nBalance of Bridge %v", balanceNodeA, balanceBridge)
 
 		// NodeA's balance is determined by subtracting amount paid from it's ledger deposit, while Bridge's balance is calculated by adding the amount received
@@ -296,7 +300,7 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 
 	t.Run("Create ledger channels on L1 and mirror it on L2", func(t *testing.T) {
 		// Alice create ledger channel with bridge
-		outcome := CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, types.Address{})
+		outcome := CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, utils.l1TokenAddress)
 		l1LedgerChannelResponse, err := nodeA.CreateLedgerChannel(bridgeAddress, uint32(tcL1.ChallengeDuration), outcome)
 		if err != nil {
 			t.Fatal(err)
@@ -312,11 +316,11 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 		l2AliceBridgeLedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
 		testhelpers.Assert(t, completedMirrorChannel == l2AliceBridgeLedgerChannelId, "Expects mirror channel id to be %v", l2AliceBridgeLedgerChannelId)
 
-		checkLedgerChannel(t, l1AliceBridgeLedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, types.Address{}), query.Open, nodeA)
-		checkLedgerChannel(t, l2AliceBridgeLedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeAPrime.Address, ledgerChannelDeposit, ledgerChannelDeposit, types.Address{}), query.Open, nodeAPrime)
+		checkLedgerChannel(t, l1AliceBridgeLedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, utils.l1TokenAddress), query.Open, nodeA)
+		checkLedgerChannel(t, l2AliceBridgeLedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeAPrime.Address, ledgerChannelDeposit, ledgerChannelDeposit, utils.l2TokenAddress), query.Open, nodeAPrime)
 
 		// Irene create ledger channel with bridge
-		outcome = CreateLedgerOutcome(*nodeC.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, types.Address{})
+		outcome = CreateLedgerOutcome(*nodeC.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, utils.l1TokenAddress)
 		l1LedgerChannelResponse, err = nodeC.CreateLedgerChannel(bridgeAddress, uint32(tcL1.ChallengeDuration), outcome)
 		if err != nil {
 			t.Fatal(err)
@@ -332,8 +336,8 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 		l2CharlieBridgeLedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
 		testhelpers.Assert(t, completedMirrorChannel == l2CharlieBridgeLedgerChannelId, "Expects mirror channel id to be %v", l2CharlieBridgeLedgerChannelId)
 
-		checkLedgerChannel(t, l1CharlieBridgeLedgerChannelId, CreateLedgerOutcome(*nodeC.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, types.Address{}), query.Open, nodeC)
-		checkLedgerChannel(t, l2CharlieBridgeLedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeCPrime.Address, ledgerChannelDeposit, ledgerChannelDeposit, types.Address{}), query.Open, nodeCPrime)
+		checkLedgerChannel(t, l1CharlieBridgeLedgerChannelId, CreateLedgerOutcome(*nodeC.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, utils.l1TokenAddress), query.Open, nodeC)
+		checkLedgerChannel(t, l2CharlieBridgeLedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeCPrime.Address, ledgerChannelDeposit, ledgerChannelDeposit, utils.l2TokenAddress), query.Open, nodeCPrime)
 	})
 
 	t.Run("Create virtual channel on mirrored ledger channel and make payments via bridge as intermediary", func(t *testing.T) {
@@ -359,8 +363,8 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 		<-nodeAPrimeObjCompleteChan
 		<-nodeCPrimeObjCompleteChan
 
-		checkLedgerChannel(t, l2AliceBridgeLedgerChannelId, CreateLedgerOutcome(*nodeAPrime.Address, bridgeAddress, ledgerChannelDeposit-payAmount, ledgerChannelDeposit+payAmount, types.Address{}), query.Open, nodeAPrime)
-		checkLedgerChannel(t, l2CharlieBridgeLedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeCPrime.Address, ledgerChannelDeposit-payAmount, ledgerChannelDeposit+payAmount, types.Address{}), query.Open, nodeCPrime)
+		checkLedgerChannel(t, l2AliceBridgeLedgerChannelId, CreateLedgerOutcome(*nodeAPrime.Address, bridgeAddress, ledgerChannelDeposit-payAmount, ledgerChannelDeposit+payAmount, utils.l2TokenAddress), query.Open, nodeAPrime)
+		checkLedgerChannel(t, l2CharlieBridgeLedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeCPrime.Address, ledgerChannelDeposit-payAmount, ledgerChannelDeposit+payAmount, utils.l2TokenAddress), query.Open, nodeCPrime)
 	})
 
 	t.Run("Exit to L1 using updated L2 ledger channel states after making payments", func(t *testing.T) {
@@ -385,7 +389,8 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 			}
 		}
 
-		checkLedgerChannel(t, l1AliceBridgeLedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, ledgerChannelDeposit+payAmount, types.Address{}), query.Complete, nodeA)
+		// TODO: Fix asset address mismatch in get ledger channel query after mirror bridged defund
+		checkLedgerChannel(t, l1AliceBridgeLedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, ledgerChannelDeposit+payAmount, utils.l2TokenAddress), query.Complete, nodeA)
 
 		completedObjectiveChannel = nodeC.CompletedObjectives()
 		// Charlie exits
@@ -408,10 +413,11 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 			}
 		}
 
-		checkLedgerChannel(t, l1CharlieBridgeLedgerChannelId, CreateLedgerOutcome(*nodeC.Address, bridgeAddress, ledgerChannelDeposit+payAmount, ledgerChannelDeposit-payAmount, types.Address{}), query.Complete, nodeC)
+		// TODO: Fix asset address mismatch in get ledger channel query after mirror bridged defund
+		checkLedgerChannel(t, l1CharlieBridgeLedgerChannelId, CreateLedgerOutcome(*nodeC.Address, bridgeAddress, ledgerChannelDeposit+payAmount, ledgerChannelDeposit-payAmount, utils.l2TokenAddress), query.Complete, nodeC)
 
-		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
-		balanceNodeC, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[2].Address())
+		balanceNodeA, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[0].Address())
+		balanceNodeC, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[2].Address())
 		t.Logf("Balance of node A %v \nBalance of node C %v", balanceNodeA, balanceNodeC)
 
 		// NodeA's balance is determined by subtracting amount paid from its ledger deposit, while NodeC's balance is calculated by adding the amount received to its ledger deposit
@@ -428,9 +434,8 @@ func TestBridgedFundWithChallenge(t *testing.T) {
 	nodeA, nodeAPrime := utils.nodeA, utils.nodeAPrime
 	bridge, bridgeAddress := utils.bridge, utils.bridgeAddress
 	storeA, storeAPrime := utils.storeA, utils.storeAPrime
-	infraL1 := utils.infraL1
 
-	l1LedgerChannelId, l2LedgerChannelId := createMirrorChannel(t, nodeA, bridge, tcL1.ChallengeDuration)
+	l1LedgerChannelId, l2LedgerChannelId := createMirrorChannel(t, nodeA, bridge, tcL1.ChallengeDuration, utils.l1TokenAddress)
 	createVirtualChannelAndMakePayment(t, nodeAPrime, bridgeAddress, tcL2.ChallengeDuration)
 
 	t.Run("Unilaterally exit to L1 using updated L2 ledger channel state after making payments", func(t *testing.T) {
@@ -457,8 +462,8 @@ func TestBridgedFundWithChallenge(t *testing.T) {
 		}
 		testhelpers.Assert(t, objective.OwnsChannel() == l1LedgerChannelId, "Expects L1 ledger channel Id to be %v", l1LedgerChannelId)
 
-		balanceNodeA, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[0].Address())
-		balanceBridge, _ := infraL1.anvilChain.GetAccountBalance(tcL1.Participants[1].Address())
+		balanceNodeA, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[0].Address())
+		balanceBridge, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[1].Address())
 		t.Logf("Balance of node A %v \nBalance of Bridge %v", balanceNodeA, balanceBridge)
 
 		// NodeA's balance is determined by subtracting amount paid from it's ledger deposit, while Bridge's balance is calculated by adding the amount received
@@ -857,6 +862,18 @@ func initializeUtilsWithBridge(t *testing.T, closeBridge bool) (UtilsWithBridge,
 
 	infraL2 := setupSharedInfra(tcL2)
 
+	// Deploy and transfer tokens
+	l1TokenAddress, l1TokenBinding, err := chain.DeployAndTransferToken(context.Background(), infraL1.anvilChain.ChainUrl, infraL1.anvilChain.ChainAuthToken, infraL1.anvilChain.ChainPks[tcL1.Participants[1].ChainAccountIndex], []common.Address{GetEthereumAddress(infraL1.anvilChain.ChainPks[tcL1.Participants[0].ChainAccountIndex]), GetEthereumAddress(infraL1.anvilChain.ChainPks[tcL1.Participants[2].ChainAccountIndex])})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Deploy and transfer tokens
+	l2TokenAddress, l2TokenBinding, err := chain.DeployAndTransferToken(context.Background(), infraL2.anvilChain.ChainUrl, infraL2.anvilChain.ChainAuthToken, infraL2.anvilChain.ChainPks[tcL2.Participants[0].ChainAccountIndex], []common.Address{GetEthereumAddress(infraL2.anvilChain.ChainPks[tcL2.Participants[1].ChainAccountIndex]), GetEthereumAddress(infraL2.anvilChain.ChainPks[tcL2.Participants[2].ChainAccountIndex])})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	bridgeConfig := bridge.BridgeConfig{
 		L1ChainUrl:        infraL1.anvilChain.ChainUrl,
 		L2ChainUrl:        infraL2.anvilChain.ChainUrl,
@@ -872,6 +889,12 @@ func initializeUtilsWithBridge(t *testing.T, closeBridge bool) (UtilsWithBridge,
 		BridgePublicIp:    DEFAULT_PUBLIC_IP,
 		NodeL1MsgPort:     int(tcL1.Participants[1].Port),
 		NodeL2MsgPort:     int(tcL2.Participants[0].Port),
+		Assets: []bridge.Asset{
+			{
+				L1AssetAddress: l1TokenAddress.String(),
+				L2AssetAddress: l2TokenAddress.String(),
+			},
+		},
 	}
 
 	bridge := bridge.New()
@@ -900,6 +923,10 @@ func initializeUtilsWithBridge(t *testing.T, closeBridge bool) (UtilsWithBridge,
 		storeAPrime:          storeAPrime,
 		infraL1:              infraL1,
 		infraL2:              infraL2,
+		l1TokenAddress:       l1TokenAddress,
+		l2TokenAddress:       l2TokenAddress,
+		l1TokenBinding:       l1TokenBinding,
+		l2TokenBinding:       l2TokenBinding,
 	}
 
 	cleanupUtilsWithBridge := func() {
@@ -919,8 +946,8 @@ func initializeUtilsWithBridge(t *testing.T, closeBridge bool) (UtilsWithBridge,
 	return utils, cleanupUtilsWithBridge
 }
 
-func createMirrorChannel(t *testing.T, node node.Node, bridge *bridge.Bridge, challengeDuration uint) (types.Destination, types.Destination) {
-	outcome := CreateLedgerOutcome(*node.Address, bridge.GetBridgeAddress(), ledgerChannelDeposit, 0, types.Address{})
+func createMirrorChannel(t *testing.T, node node.Node, bridge *bridge.Bridge, challengeDuration uint, l1AssetAddress common.Address) (types.Destination, types.Destination) {
+	outcome := CreateLedgerOutcome(*node.Address, bridge.GetBridgeAddress(), ledgerChannelDeposit, 0, l1AssetAddress)
 	l1LedgerChannelResponse, err := node.CreateLedgerChannel(bridge.GetBridgeAddress(), uint32(challengeDuration), outcome)
 	if err != nil {
 		t.Fatal(err)

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -132,8 +132,7 @@ func TestBridgedFund(t *testing.T) {
 			}
 		}
 
-		// TODO: Fix asset address mismatch in get ledger channel query after mirror bridged defund
-		checkLedgerChannel(t, l1LedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, payAmount, utils.l2TokenAddress), query.Complete, nodeA)
+		checkLedgerChannel(t, l1LedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, payAmount, utils.l1TokenAddress), query.Complete, nodeA)
 
 		balanceNodeA, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[0].Address())
 		balanceBridge, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[1].Address())
@@ -389,8 +388,7 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 			}
 		}
 
-		// TODO: Fix asset address mismatch in get ledger channel query after mirror bridged defund
-		checkLedgerChannel(t, l1AliceBridgeLedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, ledgerChannelDeposit+payAmount, utils.l2TokenAddress), query.Complete, nodeA)
+		checkLedgerChannel(t, l1AliceBridgeLedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit-payAmount, ledgerChannelDeposit+payAmount, utils.l1TokenAddress), query.Complete, nodeA)
 
 		completedObjectiveChannel = nodeC.CompletedObjectives()
 		// Charlie exits
@@ -413,8 +411,7 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 			}
 		}
 
-		// TODO: Fix asset address mismatch in get ledger channel query after mirror bridged defund
-		checkLedgerChannel(t, l1CharlieBridgeLedgerChannelId, CreateLedgerOutcome(*nodeC.Address, bridgeAddress, ledgerChannelDeposit+payAmount, ledgerChannelDeposit-payAmount, utils.l2TokenAddress), query.Complete, nodeC)
+		checkLedgerChannel(t, l1CharlieBridgeLedgerChannelId, CreateLedgerOutcome(*nodeC.Address, bridgeAddress, ledgerChannelDeposit+payAmount, ledgerChannelDeposit-payAmount, utils.l1TokenAddress), query.Complete, nodeC)
 
 		balanceNodeA, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[0].Address())
 		balanceNodeC, _ := utils.l1TokenBinding.BalanceOf(nil, tcL1.Participants[2].Address())

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -1,7 +1,6 @@
 package node_test
 
 import (
-	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -12,12 +11,12 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/crypto"
-	"github.com/statechannels/go-nitro/internal/chain"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	NitroAdjudicator "github.com/statechannels/go-nitro/node/engine/chainservice/adjudicator"
+	Token "github.com/statechannels/go-nitro/node/engine/chainservice/erc20"
 
 	"github.com/statechannels/go-nitro/node/engine/store"
 	"github.com/statechannels/go-nitro/node/query"
@@ -47,8 +46,7 @@ func TestChallenge(t *testing.T) {
 	infra := setupSharedInfra(testCase)
 	defer infra.Close(t)
 
-	// Deploy and transfer token tokens to Alice and Bob
-	tokenAddress, tokenBinding, err := chain.DeployAndTransferToken(context.Background(), infra.anvilChain.ChainUrl, infra.anvilChain.ChainAuthToken, infra.anvilChain.ChainPks[testCase.Participants[2].ChainAccountIndex], []common.Address{GetEthereumAddress(infra.anvilChain.ChainPks[testCase.Participants[0].ChainAccountIndex]), GetEthereumAddress(infra.anvilChain.ChainPks[testCase.Participants[1].ChainAccountIndex])})
+	tokenBinding, err := Token.NewToken(infra.anvilChain.ContractAddresses.TokenAddress, infra.anvilChain.EthClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +58,7 @@ func TestChallenge(t *testing.T) {
 	defer nodeB.Close()
 
 	// Create ledger channel
-	ledgerChannel := openLedgerChannel(t, nodeA, nodeB, tokenAddress, uint32(testCase.ChallengeDuration))
+	ledgerChannel := openLedgerChannel(t, nodeA, nodeB, infra.anvilChain.ContractAddresses.TokenAddress, uint32(testCase.ChallengeDuration))
 
 	// Check balance of node
 	balanceNodeA, _ := tokenBinding.BalanceOf(nil, testCase.Participants[0].Address())
@@ -122,8 +120,7 @@ func TestCheckpoint(t *testing.T) {
 	infra := setupSharedInfra(testCase)
 	defer infra.Close(t)
 
-	// Deploy and transfer token tokens to Alice and Bob
-	tokenAddress, tokenBinding, err := chain.DeployAndTransferToken(context.Background(), infra.anvilChain.ChainUrl, infra.anvilChain.ChainAuthToken, infra.anvilChain.ChainPks[testCase.Participants[2].ChainAccountIndex], []common.Address{GetEthereumAddress(infra.anvilChain.ChainPks[testCase.Participants[0].ChainAccountIndex]), GetEthereumAddress(infra.anvilChain.ChainPks[testCase.Participants[1].ChainAccountIndex])})
+	tokenBinding, err := Token.NewToken(infra.anvilChain.ContractAddresses.TokenAddress, infra.anvilChain.EthClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +132,7 @@ func TestCheckpoint(t *testing.T) {
 	defer nodeB.Close()
 
 	// Create ledger channel and check balance of node
-	ledgerChannel := openLedgerChannel(t, nodeA, nodeB, tokenAddress, uint32(testCase.ChallengeDuration))
+	ledgerChannel := openLedgerChannel(t, nodeA, nodeB, infra.anvilChain.ContractAddresses.TokenAddress, uint32(testCase.ChallengeDuration))
 
 	// Check balance of node
 	balanceNodeA, _ := tokenBinding.BalanceOf(nil, testCase.Participants[0].Address())
@@ -242,8 +239,7 @@ func TestCounterChallenge(t *testing.T) {
 	infra := setupSharedInfra(testCase)
 	defer infra.Close(t)
 
-	// Deploy and transfer token tokens to Alice and Bob
-	tokenAddress, tokenBinding, err := chain.DeployAndTransferToken(context.Background(), infra.anvilChain.ChainUrl, infra.anvilChain.ChainAuthToken, infra.anvilChain.ChainPks[testCase.Participants[2].ChainAccountIndex], []common.Address{GetEthereumAddress(infra.anvilChain.ChainPks[testCase.Participants[0].ChainAccountIndex]), GetEthereumAddress(infra.anvilChain.ChainPks[testCase.Participants[1].ChainAccountIndex])})
+	tokenBinding, err := Token.NewToken(infra.anvilChain.ContractAddresses.TokenAddress, infra.anvilChain.EthClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +251,7 @@ func TestCounterChallenge(t *testing.T) {
 	defer nodeB.Close()
 
 	// Create ledger channel and check balance of node
-	ledgerChannel := openLedgerChannel(t, nodeA, nodeB, tokenAddress, uint32(testCase.ChallengeDuration))
+	ledgerChannel := openLedgerChannel(t, nodeA, nodeB, infra.anvilChain.ContractAddresses.TokenAddress, uint32(testCase.ChallengeDuration))
 
 	// Check balance of node
 	balanceNodeA, _ := tokenBinding.BalanceOf(nil, testCase.Participants[0].Address())

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -585,6 +585,7 @@ func TestVirtualPaymentChannelWithObjective(t *testing.T) {
 	defer nodeB.Close()
 
 	// Create ledger channel and virtual fund
+	// TODO: Custom tokens are not being used since reclaim method does not support them
 	ledgerChannel := openLedgerChannel(t, nodeB, nodeA, types.Address{}, uint32(testCase.ChallengeDuration))
 	// Check balance of node
 	balanceNodeA, _ := infra.anvilChain.GetAccountBalance(testCase.Participants[0].Address())

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -348,7 +348,7 @@ func createLedgerInfo(id types.Destination, outcome outcome.Exit, status query.C
 		ID:     id,
 		Status: status,
 		Balance: query.LedgerChannelBalance{
-			AssetAddress: types.Address{},
+			AssetAddress: outcome[0].Asset,
 			Me:           me,
 			Them:         them,
 			MyBalance:    (*hexutil.Big)(myBalance),

--- a/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
+++ b/protocols/mirrorbridgeddefund/mirrorbridgeddefund.go
@@ -314,6 +314,7 @@ func (o *Objective) CreateL1StateBasedOnL2() (state.State, error) {
 	tempAllocation := l1OutcomeBasedOnL2[0].Allocations[0]
 	l1OutcomeBasedOnL2[0].Allocations[0] = l1OutcomeBasedOnL2[0].Allocations[1]
 	l1OutcomeBasedOnL2[0].Allocations[1] = tempAllocation
+	l1OutcomeBasedOnL2[0].Asset = l1State.VariablePart().Outcome[0].Asset
 	l1VariablePartBasedOnL2.Outcome = l1OutcomeBasedOnL2
 
 	l1VariablePartBasedOnL2.TurnNum++


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Deploy and transfer the custom token while setting up the test infrastructure
- Use custom token in challenge and bridge tests
- Fix asset address mismatch in get ledger channel query after mirror bridged defund completion