### PR TITLE
Implement CLI command to retrieve node information

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -617,3 +617,7 @@ func (b *Bridge) GetPendingBridgeTxs(channelId types.Destination) []PendingTx {
 
 	return foundPendingTx
 }
+
+func (b *Bridge) GetNodeInfo() types.NodeInfo {
+	return b.nodeL1.GetNodeInfo()
+}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -619,5 +619,6 @@ func (b *Bridge) GetPendingBridgeTxs(channelId types.Destination) []PendingTx {
 }
 
 func (b *Bridge) GetNodeInfo() types.NodeInfo {
+	// State channel address and message service peer ID for both the L1 and L2 nodes are same because the same private key is being used for both nodes
 	return b.nodeL1.GetNodeInfo()
 }

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -1326,3 +1326,10 @@ func (e *Engine) checkError(err error) {
 		panic(err)
 	}
 }
+
+func (e *Engine) GetNodeInfo() types.NodeInfo {
+	return types.NodeInfo{
+		SCAddress:            e.store.GetAddress().String(),
+		MessageServicePeerId: e.msg.PeerId(),
+	}
+}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -1330,6 +1330,6 @@ func (e *Engine) checkError(err error) {
 func (e *Engine) GetNodeInfo() types.NodeInfo {
 	return types.NodeInfo{
 		SCAddress:            e.store.GetAddress().String(),
-		MessageServicePeerId: e.msg.PeerId(),
+		MessageServicePeerId: e.msg.Id().String(),
 	}
 }

--- a/node/engine/messageservice/messageservice.go
+++ b/node/engine/messageservice/messageservice.go
@@ -2,6 +2,7 @@
 package messageservice // import "github.com/statechannels/go-nitro/node/messageservice"
 
 import (
+	"github.com/libp2p/go-libp2p/core/peer"
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/protocols"
 )
@@ -16,5 +17,5 @@ type MessageService interface {
 	// Close closes the message service
 	Close() error
 
-	PeerId() string
+	Id() peer.ID
 }

--- a/node/engine/messageservice/messageservice.go
+++ b/node/engine/messageservice/messageservice.go
@@ -15,4 +15,6 @@ type MessageService interface {
 	Send(protocols.Message) error
 	// Close closes the message service
 	Close() error
+
+	PeerId() string
 }

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -233,11 +233,6 @@ func (ms *P2PMessageService) Id() peer.ID {
 	return ms.p2pHost.ID()
 }
 
-// PeerId returns the libp2p peer ID (string) of the message service.
-func (ms *P2PMessageService) PeerId() string {
-	return ms.p2pHost.ID().String()
-}
-
 // addScaddrDhtRecord adds this node's state channel address to the custom dht namespace
 func (ms *P2PMessageService) addScaddrDhtRecord(ctx context.Context) {
 	ms.logger.Debug("Adding state channel address to dht")

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -233,6 +233,11 @@ func (ms *P2PMessageService) Id() peer.ID {
 	return ms.p2pHost.ID()
 }
 
+// PeerId returns the libp2p peer ID (string) of the message service.
+func (ms *P2PMessageService) PeerId() string {
+	return ms.p2pHost.ID().String()
+}
+
 // addScaddrDhtRecord adds this node's state channel address to the custom dht namespace
 func (ms *P2PMessageService) addScaddrDhtRecord(ctx context.Context) {
 	ms.logger.Debug("Adding state channel address to dht")

--- a/node/engine/messageservice/test-messageservice.go
+++ b/node/engine/messageservice/test-messageservice.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/libp2p/go-libp2p/core/peer"
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/rand"
@@ -118,7 +119,7 @@ func (tms TestMessageService) Close() error {
 	return nil
 }
 
-func (tms TestMessageService) PeerId() string {
+func (tms TestMessageService) Id() peer.ID {
 	return ""
 }
 

--- a/node/engine/messageservice/test-messageservice.go
+++ b/node/engine/messageservice/test-messageservice.go
@@ -118,6 +118,10 @@ func (tms TestMessageService) Close() error {
 	return nil
 }
 
+func (tms TestMessageService) PeerId() string {
+	return ""
+}
+
 // ┌──────────┐toMsg       in┌───────────┐
 // │          │  ───────────►|           │
 // │  Engine  │              │  Message  │

--- a/node/node.go
+++ b/node/node.go
@@ -415,3 +415,7 @@ func (n *Node) CounterChallenge(id types.Destination, action types.CounterChalle
 func (n *Node) RetryObjectiveTx(objectiveId protocols.ObjectiveId) {
 	n.engine.RetryObjectiveTxRequestFromAPI <- types.RetryObjectiveTxRequest{ObjectiveId: string(objectiveId)}
 }
+
+func (n *Node) GetNodeInfo() types.NodeInfo {
+	return n.engine.GetNodeInfo()
+}

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -60,6 +60,25 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
+    "get-node-info",
+    "Get the information of the nitro node",
+    async () => {},
+    async (yargs) => {
+      const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
+      const isSecure = yargs.s;
+
+      const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
+        getRPCUrl(rpcHost, rpcPort),
+        isSecure
+      );
+      const nodeInfo = await rpcClient.GetNodeInfo();
+      console.log(nodeInfo);
+      await rpcClient.Close();
+      process.exit(0);
+    }
+  )
+  .command(
     "address",
     "Get the address of the Nitro RPC server",
     async () => {},

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -18,6 +18,7 @@ import {
   CounterChallengeResult,
   ObjectiveCompleteNotification,
   MirrorBridgedDefundObjectiveRequest,
+  GetNodeInfo,
 } from "./types";
 import { Transport } from "./transport";
 import { createOutcome, generateRequest } from "./utils";
@@ -261,6 +262,10 @@ export class NitroRpcClient implements RpcClientApi {
 
   public async GetVersion(): Promise<string> {
     return this.sendRequest("version", {});
+  }
+
+  public async GetNodeInfo(): Promise<GetNodeInfo> {
+    return this.sendRequest("get_node_info", {});
   }
 
   public async GetAddress(): Promise<string> {

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -132,6 +132,15 @@ const receiveVoucherSchema = {
 
 type ReceiveVoucherSchemaType = JTDDataType<typeof receiveVoucherSchema>;
 
+const GetNodeInfoSchema = {
+  properties: {
+    SCAddress: { type: "string" },
+    MessageServicePeerId: { type: "string" },
+  },
+} as const;
+
+type GetNodeInfoSchemaType = JTDDataType<typeof GetNodeInfoSchema>;
+
 type ResponseSchema =
   | typeof objectiveSchema
   | typeof stringSchema
@@ -142,7 +151,8 @@ type ResponseSchema =
   | typeof paymentSchema
   | typeof voucherSchema
   | typeof receiveVoucherSchema
-  | typeof counterChallengeSchema;
+  | typeof counterChallengeSchema
+  | typeof GetNodeInfoSchema;
 
 type ResponseSchemaType =
   | ObjectiveSchemaType
@@ -154,7 +164,8 @@ type ResponseSchemaType =
   | PaymentSchemaType
   | VoucherSchemaType
   | ReceiveVoucherSchemaType
-  | CounterChallengeSchemaType;
+  | CounterChallengeSchemaType
+  | GetNodeInfoSchemaType;
 
 /**
  * Validates that the response is a valid JSON RPC response with a valid result
@@ -259,7 +270,12 @@ export function getAndValidateResult<T extends RequestMethod>(
           Signature: result.Signature,
         })
       );
-
+    case "get_node_info":
+      return validateAndConvertResult(
+        GetNodeInfoSchema,
+        result,
+        (result: GetNodeInfoSchemaType) => result
+      );
     default:
       throw new Error(`Unknown method: ${method}`);
   }

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -132,14 +132,14 @@ const receiveVoucherSchema = {
 
 type ReceiveVoucherSchemaType = JTDDataType<typeof receiveVoucherSchema>;
 
-const GetNodeInfoSchema = {
+const getNodeInfoSchema = {
   properties: {
     SCAddress: { type: "string" },
     MessageServicePeerId: { type: "string" },
   },
 } as const;
 
-type GetNodeInfoSchemaType = JTDDataType<typeof GetNodeInfoSchema>;
+type GetNodeInfoSchemaType = JTDDataType<typeof getNodeInfoSchema>;
 
 type ResponseSchema =
   | typeof objectiveSchema
@@ -152,7 +152,7 @@ type ResponseSchema =
   | typeof voucherSchema
   | typeof receiveVoucherSchema
   | typeof counterChallengeSchema
-  | typeof GetNodeInfoSchema;
+  | typeof getNodeInfoSchema;
 
 type ResponseSchemaType =
   | ObjectiveSchemaType
@@ -272,7 +272,7 @@ export function getAndValidateResult<T extends RequestMethod>(
       );
     case "get_node_info":
       return validateAndConvertResult(
-        GetNodeInfoSchema,
+        getNodeInfoSchema,
         result,
         (result: GetNodeInfoSchemaType) => result
       );

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -210,6 +210,11 @@ export type CreateVoucherRequest = JsonRpcRequest<
 
 export type ReceiveVoucherRequest = JsonRpcRequest<"receive_voucher", Voucher>;
 
+export type GetNodeInfoRequest = JsonRpcRequest<
+  "get_node_info",
+  Record<string, never>
+>;
+
 /**
  * RPC Responses
  */
@@ -221,6 +226,7 @@ export type CounterChallengeResponse = JsonRpcResponse<CounterChallengeResult>;
 export type GetLedgerChannelResponse = JsonRpcResponse<LedgerChannelInfo>;
 export type VirtualFundResponse = JsonRpcResponse<ObjectiveResponse>;
 export type VersionResponse = JsonRpcResponse<string>;
+export type GetNodeInfoResponse = JsonRpcResponse<GetNodeInfo>;
 export type GetAddressResponse = JsonRpcResponse<string>;
 export type DirectFundResponse = JsonRpcResponse<ObjectiveResponse>;
 export type RetryObjectiveTxResponse = JsonRpcResponse<string>;
@@ -255,6 +261,7 @@ export type RPCRequestAndResponses = {
     MirrorBridgedDefundResponse
   ];
   version: [VersionRequest, VersionResponse];
+  get_node_info: [GetNodeInfoRequest, GetNodeInfoResponse];
   create_payment_channel: [VirtualFundRequest, VirtualFundResponse];
   get_address: [GetAddressRequest, GetAddressResponse];
   get_ledger_channel: [GetLedgerChannelRequest, GetLedgerChannelResponse];
@@ -400,3 +407,8 @@ export enum ChannelMode {
   Challenge,
   Finalized,
 }
+
+export type GetNodeInfo = {
+  SCAddress: string;
+  MessageServicePeerId: string;
+};

--- a/rpc/bridge-server.go
+++ b/rpc/bridge-server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/statechannels/go-nitro/protocols/bridgeddefund"
 	"github.com/statechannels/go-nitro/rpc/serde"
 	"github.com/statechannels/go-nitro/rpc/transport"
+	"github.com/statechannels/go-nitro/types"
 )
 
 type BridgeRpcServer struct {
@@ -168,6 +169,10 @@ func (brs *BridgeRpcServer) registerHandlers() (err error) {
 				}
 
 				return string(marshalledPendingBridgeTxs), nil
+			})
+		case serde.GetNodeInfoRequestMethod:
+			return processRequest(brs.BaseRpcServer, permSign, requestData, func(req serde.NoPayloadRequest) (types.NodeInfo, error) {
+				return brs.bridge.GetNodeInfo(), nil
 			})
 		default:
 			errRes := serde.NewJsonRpcErrorResponse(jsonrpcReq.Id, serde.MethodNotFoundError)

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -166,6 +166,10 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req virtualdefund.ObjectiveRequest) (protocols.ObjectiveId, error) {
 				return nrs.node.ClosePaymentChannel(req.ChannelId)
 			})
+		case serde.GetNodeInfoRequestMethod:
+			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.NoPayloadRequest) (types.NodeInfo, error) {
+				return nrs.node.GetNodeInfo(), nil
+			})
 		case serde.PayRequestMethod:
 			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.PaymentRequest) (serde.PaymentRequest, error) {
 				if err := serde.ValidatePaymentRequest(req); err != nil {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -32,6 +32,7 @@ const (
 	GetLedgerChannelRequestMethod     RequestMethod = "get_ledger_channel"
 	GetPaymentChannelsByLedgerMethod  RequestMethod = "get_payment_channels_by_ledger"
 	GetAllLedgerChannelsMethod        RequestMethod = "get_all_ledger_channels"
+	GetNodeInfoRequestMethod          RequestMethod = "get_node_info"
 	CreateVoucherRequestMethod        RequestMethod = "create_voucher"
 	ReceiveVoucherRequestMethod       RequestMethod = "receive_voucher"
 	CounterChallengeRequestMethod     RequestMethod = "counter_challenge"
@@ -198,7 +199,8 @@ type ResponsePayload interface {
 		string |
 		payments.ReceiveVoucherSummary |
 		CounterChallengeRequest |
-		ValidateVoucherResponse
+		ValidateVoucherResponse |
+		types.NodeInfo
 }
 
 type JsonRpcSuccessResponse[T ResponsePayload] struct {

--- a/types/types.go
+++ b/types/types.go
@@ -43,3 +43,8 @@ const (
 type RetryObjectiveTxRequest struct {
 	ObjectiveId string
 }
+
+type NodeInfo struct {
+	SCAddress            string
+	MessageServicePeerId string
+}


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)

- Show peer ID and state channel address in CLI