### PR TITLE
Add bridge RPC test to create mirror channel

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn test:contracts
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs
           path: ./**/*.log

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: integration-test-logs
           path: ./**/*.log

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: rpc server logs
           path: ./output.log

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -594,16 +594,16 @@ func (b *Bridge) checkAndRetryDroppedTxs(droppedEvent protocols.DroppedEventInfo
 	if txToRetry.NumOfRetries >= RETRY_TX_LIMIT {
 		txToRetry.IsRetryLimitReached = true
 		b.sentTxs.Store(droppedEvent.TxHash.String(), txToRetry)
-	} else {
-		retriedTx, err := chainservice.SendTransaction(txToRetry.Tx)
-		if err != nil {
-			return err
-		}
-
-		b.sentTxs.Delete(droppedEvent.TxHash.String())
-		b.sentTxs.Store(retriedTx.Hash().String(), SentTx{txToRetry.Tx, txToRetry.NumOfRetries + 1, false, isL2})
+		return nil
 	}
 
+	retriedTx, err := chainservice.SendTransaction(txToRetry.Tx)
+	if err != nil {
+		return err
+	}
+
+	b.sentTxs.Delete(droppedEvent.TxHash.String())
+	b.sentTxs.Store(retriedTx.Hash().String(), SentTx{txToRetry.Tx, txToRetry.NumOfRetries + 1, false, isL2})
 	return nil
 }
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -47,7 +47,7 @@ type L1ToL2AssetConfig struct {
 type SentTx struct {
 	Tx           protocols.ChainTransaction `json:"tx"`
 	NumOfRetries uint                       `json:"num_of_retries"`
-	IsDropped    bool                       `json:"is_dropped"`
+	IsRetried    bool                       `json:"is_retried"`
 	IsL2         bool                       `json:"is_l2"`
 }
 
@@ -522,7 +522,7 @@ func (b *Bridge) RetryTx(txHash common.Hash) error {
 		return fmt.Errorf("tx with given hash %s was either complete or cannot be found", txHash)
 	}
 
-	if !txToRetry.IsDropped {
+	if !txToRetry.IsRetried {
 		return fmt.Errorf("tx with given hash %s is pending confirmation and connot be retried", txHash)
 	}
 
@@ -589,7 +589,7 @@ func (b *Bridge) checkAndRetryDroppedTxs(droppedEvent protocols.DroppedEventInfo
 	txToRetry, ok := b.sentTxs.Load(droppedEvent.TxHash.String())
 
 	if ok {
-		txToRetry.IsDropped = true
+		txToRetry.IsRetried = true
 		b.sentTxs.Store(droppedEvent.TxHash.String(), txToRetry)
 	}
 

--- a/node_test/bridge_rpc_test.go
+++ b/node_test/bridge_rpc_test.go
@@ -1,0 +1,53 @@
+package node_test
+
+import (
+	"crypto/tls"
+	"log"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/statechannels/go-nitro/bridge"
+	"github.com/statechannels/go-nitro/internal/logging"
+	internalRpc "github.com/statechannels/go-nitro/internal/rpc"
+	"github.com/statechannels/go-nitro/rpc"
+	"github.com/statechannels/go-nitro/rpc/transport/http"
+)
+
+const BRIDGE_RPC_PORT = 4006
+
+func setupBridgeWithRPCClient(
+	t *testing.T,
+	bridgeConfig bridge.BridgeConfig,
+) rpc.RpcClientApi {
+	logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)
+	bridge := bridge.New()
+
+	_, _, _, _, err := bridge.Start(bridgeConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cert, err := tls.LoadX509KeyPair("../tls/statechannels.org.pem", "../tls/statechannels.org_key.pem")
+	if err != nil {
+		panic(err)
+	}
+
+	bridgeRpcServer, err := internalRpc.InitializeBridgeRpcServer(bridge, BRIDGE_RPC_PORT, false, &cert)
+	if err != nil {
+		panic(err)
+	}
+
+	clientConnection, err := http.NewHttpTransportAsClient(bridgeRpcServer.Url(), true, 10*time.Millisecond)
+	if err != nil {
+		panic(err)
+	}
+
+	rpcClient, err := rpc.NewRpcClient(clientConnection)
+	if err != nil {
+		panic(err)
+	}
+
+	return rpcClient
+}

--- a/node_test/bridge_rpc_test.go
+++ b/node_test/bridge_rpc_test.go
@@ -212,6 +212,7 @@ func TestBridgeFlow(t *testing.T) {
 	})
 
 	t.Run("Exit to L1 using updated L2 ledger channel state after making payments", func(t *testing.T) {
+		// Bridged defund is currently disabled
 		t.Skip()
 		_, err = nodeAPrimeRpcClient.CloseBridgeChannel(l2LedgerChannelId)
 		checkError(t, err, "client.CloseBridgeChannel")

--- a/node_test/bridge_rpc_test.go
+++ b/node_test/bridge_rpc_test.go
@@ -49,5 +49,19 @@ func setupBridgeWithRPCClient(
 		panic(err)
 	}
 
+	// TODO: Add cleanup function to close bridge server and client
+
 	return rpcClient
+}
+
+func TestBridgeFlow() {
+	// TODO: Check if bridge client is really required
+
+	// TODO: Use setup function to setup bridge server and client
+	// TODO: use node setup function to setup L1 and L2 nodes
+	// TODO: Perform directfund between L1 node and bridge using L1 node's RPC client
+	// TODO: Check that bridge channel is established
+	// TODO: Create virtual channel, make payments and close virtual channel
+	// TODO: Close bridge channel using L2 node's RPC client
+	// TODO: Check that corresponding ledger channel is closed
 }

--- a/node_test/bridge_rpc_test.go
+++ b/node_test/bridge_rpc_test.go
@@ -8,10 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/bridge"
 	"github.com/statechannels/go-nitro/internal/logging"
 	internalRpc "github.com/statechannels/go-nitro/internal/rpc"
+	"github.com/statechannels/go-nitro/internal/testactors"
+	"github.com/statechannels/go-nitro/internal/testhelpers"
+	"github.com/statechannels/go-nitro/node/engine/chainservice"
+	Token "github.com/statechannels/go-nitro/node/engine/chainservice/erc20"
 	"github.com/statechannels/go-nitro/rpc"
+	"github.com/statechannels/go-nitro/rpc/transport"
 	"github.com/statechannels/go-nitro/rpc/transport/http"
 )
 
@@ -20,11 +26,11 @@ const BRIDGE_RPC_PORT = 4006
 func setupBridgeWithRPCClient(
 	t *testing.T,
 	bridgeConfig bridge.BridgeConfig,
-) rpc.RpcClientApi {
+) (rpc.RpcClientApi, string, string) {
 	logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)
 	bridge := bridge.New()
 
-	_, _, _, _, err := bridge.Start(bridgeConfig)
+	_, _, nodeL1MultiAddress, nodeL2MultiAddress, err := bridge.Start(bridgeConfig)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -51,14 +57,89 @@ func setupBridgeWithRPCClient(
 
 	// TODO: Add cleanup function to close bridge server and client
 
-	return rpcClient
+	return rpcClient, nodeL1MultiAddress, nodeL2MultiAddress
 }
 
-func TestBridgeFlow() {
+func TestBridgeFlow(t *testing.T) {
 	// TODO: Check if bridge client is really required
+	tcL1 := TestCase{
+		Chain:             AnvilChainL1,
+		MessageService:    P2PMessageService,
+		MessageDelay:      0,
+		LogName:           "Bridge_test",
+		ChallengeDuration: 5,
+		Participants: []TestParticipant{
+			{StoreType: MemStore, Actor: testactors.Alice},
+			{StoreType: MemStore, Actor: testactors.Bob},
+			{StoreType: MemStore, Actor: testactors.Irene},
+		},
+		deployerIndex: 1,
+	}
 
+	tcL2 := TestCase{
+		Chain:             AnvilChainL2,
+		MessageService:    P2PMessageService,
+		MessageDelay:      0,
+		LogName:           "Bridge_test",
+		ChallengeDuration: 5,
+		Participants: []TestParticipant{
+			{StoreType: MemStore, Actor: testactors.BobPrime},
+			{StoreType: MemStore, Actor: testactors.AlicePrime},
+			{StoreType: MemStore, Actor: testactors.Irene},
+		},
+		ChainPort:     "8546",
+		deployerIndex: 0,
+	}
+
+	dataFolder, _ := testhelpers.GenerateTempStoreFolder()
+
+	infraL1 := setupSharedInfra(tcL1)
+
+	infraL2 := setupSharedInfra(tcL2)
+
+	_, err := Token.NewToken(infraL1.anvilChain.ContractAddresses.TokenAddress, infraL1.anvilChain.EthClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Token.NewToken(infraL2.anvilChain.ContractAddresses.TokenAddress, infraL2.anvilChain.EthClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bridgeConfig := bridge.BridgeConfig{
+		L1ChainUrl:        infraL1.anvilChain.ChainUrl,
+		L2ChainUrl:        infraL2.anvilChain.ChainUrl,
+		L1ChainStartBlock: 0,
+		L2ChainStartBlock: 0,
+		ChainPK:           infraL1.anvilChain.ChainPks[tcL1.Participants[1].ChainAccountIndex],
+		StateChannelPK:    common.Bytes2Hex(tcL1.Participants[1].PrivateKey),
+		NaAddress:         infraL1.anvilChain.ContractAddresses.NaAddress.String(),
+		VpaAddress:        infraL1.anvilChain.ContractAddresses.VpaAddress.String(),
+		CaAddress:         infraL1.anvilChain.ContractAddresses.CaAddress.String(),
+		BridgeAddress:     infraL2.anvilChain.ContractAddresses.BridgeAddress.String(),
+		DurableStoreDir:   dataFolder,
+		BridgePublicIp:    DEFAULT_PUBLIC_IP,
+		NodeL1MsgPort:     int(tcL1.Participants[1].Port),
+		NodeL2MsgPort:     int(tcL2.Participants[0].Port),
+		Assets: []bridge.Asset{
+			{
+				L1AssetAddress: infraL1.anvilChain.ContractAddresses.TokenAddress.String(),
+				L2AssetAddress: infraL2.anvilChain.ContractAddresses.TokenAddress.String(),
+			},
+		},
+	}
+
+	nodeAMockChainservice := chainservice.NewMockChainService(infraL1.mockChain, tcL1.Participants[0].Address())
+	nodeAPrimeMockChainservice := chainservice.NewMockChainService(infraL2.mockChain, tcL2.Participants[1].Address())
 	// TODO: Use setup function to setup bridge server and client
+	bridgeClient, nodeL1MultiAddress, nodeL2MultiAddress := setupBridgeWithRPCClient(t, bridgeConfig)
 	// TODO: use node setup function to setup L1 and L2 nodes
+	nodeARpcClient, _, _ := setupNitroNodeWithRPCClient(t, tcL1.Participants[0].PrivateKey, int(tcL1.Participants[0].Port), int(tcL1.Participants[0].WSPort), 4007, nodeAMockChainservice, transport.Http, []string{nodeL1MultiAddress})
+
+	nodeAPrimeRpcClient, _, _ := setupNitroNodeWithRPCClient(t, tcL2.Participants[1].PrivateKey, int(tcL2.Participants[1].Port), int(tcL2.Participants[1].WSPort), 4008, nodeAPrimeMockChainservice, transport.Http, []string{nodeL2MultiAddress})
+
+	// TODO: Use clients to perform following flow
 	// TODO: Perform directfund between L1 node and bridge using L1 node's RPC client
 	// TODO: Check that bridge channel is established
 	// TODO: Create virtual channel, make payments and close virtual channel

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -75,7 +75,7 @@ func TestBridgedFund(t *testing.T) {
 		t.Log("L1 channel created", l1LedgerChannelResponse.Id)
 
 		// Wait for mirror channel to be created
-		completedMirrorChannel := <-bridge.CompletedMirrorChannels()
+		completedMirrorChannel := <-bridge.CreatedMirrorChannels()
 		l2LedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
 		testhelpers.Assert(t, completedMirrorChannel == l2LedgerChannelId, "Expects mirror channel id to be %v", l2LedgerChannelId)
 		checkLedgerChannel(t, l1LedgerChannelResponse.ChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, infraL2.anvilChain.ContractAddresses.TokenAddress), query.Open, nodeA)
@@ -310,7 +310,7 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 		t.Log("L1 channel created", l1LedgerChannelResponse.Id)
 
 		// Wait for mirror channel to be created
-		completedMirrorChannel := <-bridge.CompletedMirrorChannels()
+		completedMirrorChannel := <-bridge.CreatedMirrorChannels()
 
 		l2AliceBridgeLedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
 		testhelpers.Assert(t, completedMirrorChannel == l2AliceBridgeLedgerChannelId, "Expects mirror channel id to be %v", l2AliceBridgeLedgerChannelId)
@@ -330,7 +330,7 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 		<-nodeC.ObjectiveCompleteChan(l1LedgerChannelResponse.Id)
 		t.Log("L1 channel created", l1LedgerChannelResponse.Id)
 		// Wait for mirror channel to be created
-		completedMirrorChannel = <-bridge.CompletedMirrorChannels()
+		completedMirrorChannel = <-bridge.CreatedMirrorChannels()
 
 		l2CharlieBridgeLedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
 		testhelpers.Assert(t, completedMirrorChannel == l2CharlieBridgeLedgerChannelId, "Expects mirror channel id to be %v", l2CharlieBridgeLedgerChannelId)
@@ -953,7 +953,7 @@ func createMirrorChannel(t *testing.T, node node.Node, bridge *bridge.Bridge, ch
 	t.Log("L1 channel created", l1LedgerChannelId)
 
 	// Wait for mirror channel to be created
-	l2LedgerChannelId := <-bridge.CompletedMirrorChannels()
+	l2LedgerChannelId := <-bridge.CreatedMirrorChannels()
 	t.Log("L2 channel created", l2LedgerChannelId)
 
 	return l1LedgerChannelId, l2LedgerChannelId

--- a/node_test/bridge_test.go
+++ b/node_test/bridge_test.go
@@ -75,9 +75,9 @@ func TestBridgedFund(t *testing.T) {
 		t.Log("L1 channel created", l1LedgerChannelResponse.Id)
 
 		// Wait for mirror channel to be created
-		completedMirrorChannel := <-bridge.CreatedMirrorChannels()
+		createdMirrorChannel := <-bridge.CreatedMirrorChannels()
 		l2LedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
-		testhelpers.Assert(t, completedMirrorChannel == l2LedgerChannelId, "Expects mirror channel id to be %v", l2LedgerChannelId)
+		testhelpers.Assert(t, createdMirrorChannel == l2LedgerChannelId, "Expects mirror channel id to be %v", l2LedgerChannelId)
 		checkLedgerChannel(t, l1LedgerChannelResponse.ChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, 0, infraL2.anvilChain.ContractAddresses.TokenAddress), query.Open, nodeA)
 		checkLedgerChannel(t, l2LedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeAPrime.Address, 0, ledgerChannelDeposit, infraL2.anvilChain.ContractAddresses.TokenAddress), query.Open, nodeAPrime)
 	})
@@ -310,10 +310,10 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 		t.Log("L1 channel created", l1LedgerChannelResponse.Id)
 
 		// Wait for mirror channel to be created
-		completedMirrorChannel := <-bridge.CreatedMirrorChannels()
+		createdMirrorChannel := <-bridge.CreatedMirrorChannels()
 
 		l2AliceBridgeLedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
-		testhelpers.Assert(t, completedMirrorChannel == l2AliceBridgeLedgerChannelId, "Expects mirror channel id to be %v", l2AliceBridgeLedgerChannelId)
+		testhelpers.Assert(t, createdMirrorChannel == l2AliceBridgeLedgerChannelId, "Expects mirror channel id to be %v", l2AliceBridgeLedgerChannelId)
 
 		checkLedgerChannel(t, l1AliceBridgeLedgerChannelId, CreateLedgerOutcome(*nodeA.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, infraL1.anvilChain.ContractAddresses.TokenAddress), query.Open, nodeA)
 		checkLedgerChannel(t, l2AliceBridgeLedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeAPrime.Address, ledgerChannelDeposit, ledgerChannelDeposit, infraL2.anvilChain.ContractAddresses.TokenAddress), query.Open, nodeAPrime)
@@ -330,10 +330,10 @@ func TestBridgedFundWithIntermediary(t *testing.T) {
 		<-nodeC.ObjectiveCompleteChan(l1LedgerChannelResponse.Id)
 		t.Log("L1 channel created", l1LedgerChannelResponse.Id)
 		// Wait for mirror channel to be created
-		completedMirrorChannel = <-bridge.CreatedMirrorChannels()
+		createdMirrorChannel = <-bridge.CreatedMirrorChannels()
 
 		l2CharlieBridgeLedgerChannelId, _ = bridge.GetL2ChannelIdByL1ChannelId(l1LedgerChannelResponse.ChannelId)
-		testhelpers.Assert(t, completedMirrorChannel == l2CharlieBridgeLedgerChannelId, "Expects mirror channel id to be %v", l2CharlieBridgeLedgerChannelId)
+		testhelpers.Assert(t, createdMirrorChannel == l2CharlieBridgeLedgerChannelId, "Expects mirror channel id to be %v", l2CharlieBridgeLedgerChannelId)
 
 		checkLedgerChannel(t, l1CharlieBridgeLedgerChannelId, CreateLedgerOutcome(*nodeC.Address, bridgeAddress, ledgerChannelDeposit, ledgerChannelDeposit, infraL1.anvilChain.ContractAddresses.TokenAddress), query.Open, nodeC)
 		checkLedgerChannel(t, l2CharlieBridgeLedgerChannelId, CreateLedgerOutcome(bridgeAddress, *nodeCPrime.Address, ledgerChannelDeposit, ledgerChannelDeposit, infraL2.anvilChain.ContractAddresses.TokenAddress), query.Open, nodeCPrime)

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -395,7 +395,7 @@ func setupNitroNodeWithRPCClient(
 	msgPort int,
 	wsMsgPort int,
 	rpcPort int,
-	chain *chainservice.MockChainService,
+	chain chainservice.ChainService,
 	connectionType transport.TransportType,
 	bootPeers []string,
 ) (rpc.RpcClientApi, *p2pms.P2PMessageService, func()) {

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -73,7 +73,7 @@ yargs(hideBin(process.argv))
         isSecure
       );
       const nodeInfo = await rpcClient.GetNodeInfo();
-      console.log(nodeInfo);
+      console.log(prettyJson(nodeInfo));
       await rpcClient.Close();
       process.exit(0);
     }

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -231,7 +231,7 @@ yargs(hideBin(process.argv))
         isSecure
       );
       const objectiveInfo = await rpcClient.GetObjective(objectiveId, l2);
-      console.log(objectiveInfo);
+      prettyJson(objectiveInfo);
 
       await rpcClient.Close();
       process.exit(0);
@@ -259,7 +259,7 @@ yargs(hideBin(process.argv))
         isSecure
       );
       const objectiveInfo = await rpcClient.GetL2ObjectiveFromL1(l1ObjectiveId);
-      console.log(objectiveInfo);
+      prettyJson(objectiveInfo);
 
       await rpcClient.Close();
       process.exit(0);

--- a/readme.md
+++ b/readme.md
@@ -427,6 +427,125 @@ The on-chain component of Nitro (i.e. the solidity contracts) are housed in the 
   Result: 1000050
   ```
 
+## Steps to retry dropped txs
+
+### Direct fund
+
+- Check status of direct-fund objective
+
+  ```bash
+  nitro-rpc-client get-objective <Objective ID> -p <RPC port of the L1 node>
+
+  # Expected output:
+  # {
+  #  "Status": 1,
+  #  "DroppedTx": {
+  #    "DroppedTxHash": "0x339079c724690c6b99e15b5f04fc4e36ccdab30a83602734057c4e2f6fd04afe",
+  #    "ChannelId": "0xb08b6c111e9d0b0cb0ad31274132ac7e7542242e2a80201d9e9e5a2e78fe197d",
+  #    "EventName": "Deposited"
+  #  }
+  # }
+  ```
+
+  - This will give you status of the objective, with dropped tx details if any
+
+  - In the dropped tx details, you should see the trasaction that was dropped along with its `hash`, `channel ID`, and the `Event` associated with that tx
+
+- You can retry the dropped tx using
+
+  ```bash
+  nitro-rpc-client retry-objective-tx <Objective ID> -p <RPC port of L1 node>
+
+  # Expected output:
+  # Transaction retried for objective DirectFunding-0x1df710eba9b90784ba96b6add8c574b4511c67ab4e4c29667bbac06385b965a6
+  ```
+
+### Bridged fund
+
+- To check status of bridged-fund objective, you either need objective Id of corresponding direct-fund objective (L1 objective) or objective ID of bridged-fund objective (L2 objective)
+
+  - Using corresponding direct-fund objective (L1 objective)
+
+    ```bash
+    nitro-rpc-client get-l2-objective-from-l1 <L1 Objective ID> -p <RPC port of the bridge>
+
+    # Expected output:
+    # {
+    #  "Status": 1,
+    #  "DroppedTx": {
+    #    "DroppedTxHash": "0x339079c724690c6b99e15b5f04fc4e36ccdab30a83602734057c4e2f6fd04afe",
+    #    "ChannelId": "0xb08b6c111e9d0b0cb0ad31274132ac7e7542242e2a80201d9e9e5a2e78fe197d",
+    #    "EventName": "Deposited"
+    #  }
+    # }
+    ```
+
+  - Using objective ID of bridged-fund
+
+    ```bash
+    nitro-rpc-client get-objective <Objective ID> --l2 true -p <RPC port of the bridge>
+
+    # Expected output:
+    # {
+    #  "Status": 1,
+    #  "DroppedTx": {
+    #    "DroppedTxHash": "0x339079c724690c6b99e15b5f04fc4e36ccdab30a83602734057c4e2f6fd04afe",
+    #    "ChannelId": "0x4af740df92a57656c0d15f053e8413ded279411aec5793d8243cb1205de2d996",
+    #    "EventName": "StatusUpdated"
+    #  }
+    # }
+    ```
+
+  - This will give you status of the objective, with dropped tx details if any
+
+- You can retry the dropped tx using
+
+  ```bash
+  nitro-rpc-client retry-objective-tx <Objective ID> -p <RPC port of the L2 node / bridge>
+
+  # Expected output:
+  # Transaction retried for objective BridgedFunding-0xbda3cff692390dcc764fa9e27ddd562d9aa929447e89f5d0b4aeb780a1aea0c6
+  ```
+
+### Non-objective bridge txs
+
+- Some txs that are performed by bridge are not part of any objective
+
+- These txs are stored against channel ID
+
+- To see if these txs are confirmed or not, we can query bridge to get the pending txs
+
+  ```bash
+  nitro-rpc-client get-pending-bridge-txs <Channel ID> -p <RPC port of the bridge>
+
+  # Expected output:
+  # {
+  #  "tx_hash": "0x9aebbd42f3044295411e3631fcb6aa834ed5373a6d3bf368bfa09e5b74f4f6d1",
+  #  "num_of_retries": 3,
+  #  "is_retried": true,
+  #  "is_l2": false
+  # }
+  ```
+
+- Txs are stored against both L1 and L2 channel IDs so please check both channels see if any txs are pending
+
+- If these txs fail, bridge retries them until retry tx threshold has been met
+
+  - If there are any txs with `is_retried: false`, that means they are not auto retried by bridge just yet
+
+- If there are any txs with `is_retried: true`, it means these txs failed even after auto retry
+
+- The `get-pending-bridge-txs` command will output pending txs details along with their tx hash
+
+- To manually retry txs that failed after auto retry, use
+
+  ```bash
+  nitro-rpc-client retry-tx <Tx hash of the failed tx> -p <RPC port of the bridge>
+
+  # Expected output:
+  # Transaction with hash 0x339079c724690c6b99e15b5f04fc4e36ccdab30a83602734057c4e2f6fd04afe retried
+  ```
+
 ## License
 
 Dual-licensed under [MIT](https://opensource.org/licenses/MIT) + [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/readme.md
+++ b/readme.md
@@ -522,7 +522,7 @@ The on-chain component of Nitro (i.e. the solidity contracts) are housed in the 
   # {
   #  "tx_hash": "0x9aebbd42f3044295411e3631fcb6aa834ed5373a6d3bf368bfa09e5b74f4f6d1",
   #  "num_of_retries": 3,
-  #  "is_retried": true,
+  #  "is_retry_limit_reached": true,
   #  "is_l2": false
   # }
   ```
@@ -531,9 +531,9 @@ The on-chain component of Nitro (i.e. the solidity contracts) are housed in the 
 
 - If these txs fail, bridge retries them until retry tx threshold has been met
 
-  - If there are any txs with `is_retried: false`, that means they are not auto retried by bridge just yet
+  - If there are any txs with `is_retry_limit_reached: false`, that means they are not auto retried by bridge just yet
 
-- If there are any txs with `is_retried: true`, it means these txs failed even after auto retry
+- If there are any txs with `is_retry_limit_reached: true`, it means these txs failed even after auto retry
 
 - The `get-pending-bridge-txs` command will output pending txs details along with their tx hash
 

--- a/rpc/bridge-server.go
+++ b/rpc/bridge-server.go
@@ -170,6 +170,20 @@ func (brs *BridgeRpcServer) registerHandlers() (err error) {
 
 				return string(marshalledPendingBridgeTxs), nil
 			})
+		case serde.GetL2ChannelFromL1Method:
+			return processRequest(brs.BaseRpcServer, permSign, requestData, func(req serde.GetL2ChannelFromL1Request) (types.Destination, error) {
+				l2ChannelId, ok := brs.bridge.GetL2ChannelIdByL1ChannelId(req.L1ChannelId)
+
+				if ok {
+					return types.Destination{}, nil
+				}
+
+				return l2ChannelId, nil
+			})
+		case serde.GetAddressMethod:
+			return processRequest(brs.BaseRpcServer, permNone, requestData, func(req serde.NoPayloadRequest) (string, error) {
+				return brs.bridge.GetBridgeAddress().Hex(), nil
+			})
 		case serde.GetNodeInfoRequestMethod:
 			return processRequest(brs.BaseRpcServer, permSign, requestData, func(req serde.NoPayloadRequest) (types.NodeInfo, error) {
 				return brs.bridge.GetNodeInfo(), nil

--- a/rpc/bridge-server.go
+++ b/rpc/bridge-server.go
@@ -177,16 +177,6 @@ func (brs *BridgeRpcServer) registerHandlers() (err error) {
 
 				return string(marshalledPendingBridgeTxs), nil
 			})
-		case serde.GetL2ChannelFromL1Method:
-			return processRequest(brs.BaseRpcServer, permSign, requestData, func(req serde.GetL2ChannelFromL1Request) (types.Destination, error) {
-				l2ChannelId, ok := brs.bridge.GetL2ChannelIdByL1ChannelId(req.L1ChannelId)
-
-				if ok {
-					return types.Destination{}, nil
-				}
-
-				return l2ChannelId, nil
-			})
 		case serde.GetAddressMethod:
 			return processRequest(brs.BaseRpcServer, permNone, requestData, func(req serde.NoPayloadRequest) (string, error) {
 				return brs.bridge.GetBridgeAddress().Hex(), nil

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -83,8 +83,6 @@ type RpcClientApi interface {
 
 	ValidateVoucher(voucherHash common.Hash, signerAddress common.Address, value uint64) (serde.ValidateVoucherResponse, error)
 
-	GetL2ChannelFromL1(l1Channel types.Destination) (types.Destination, error)
-
 	CloseBridgeChannel(id types.Destination) (protocols.ObjectiveId, error)
 
 	CreatedMirrorChannel() <-chan types.Destination
@@ -219,13 +217,6 @@ func (rc *rpcClient) GetLedgerChannel(id types.Destination) (query.LedgerChannel
 // GetAllLedgerChannels returns all ledger channels
 func (rc *rpcClient) GetAllLedgerChannels() ([]query.LedgerChannelInfo, error) {
 	return waitForAuthorizedRequest[serde.NoPayloadRequest, []query.LedgerChannelInfo](rc, serde.GetAllLedgerChannelsMethod, struct{}{})
-}
-
-func (rc *rpcClient) GetL2ChannelFromL1(l1Channel types.Destination) (types.Destination, error) {
-	req := serde.GetL2ChannelFromL1Request{
-		L1ChannelId: l1Channel,
-	}
-	return waitForAuthorizedRequest[serde.GetL2ChannelFromL1Request, types.Destination](rc, serde.GetL2ChannelFromL1Method, req)
 }
 
 // GetPaymentChannelsByLedger returns all active payment channels for a given ledger channel

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -24,7 +24,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-const DISABLE_BRIDGE_DEFUND = true
+const DISABLE_BRIDGE_DEFUND = false
 
 type NodeRpcServer struct {
 	*BaseRpcServer

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -24,7 +24,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-const DISABLE_BRIDGE_DEFUND = false
+const DISABLE_BRIDGE_DEFUND = true
 
 type NodeRpcServer struct {
 	*BaseRpcServer

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -41,7 +41,6 @@ const (
 	// Bridge methods
 	GetAllL2ChannelsRequestMethod RequestMethod = "get_all_l2_channels"
 	GetL2ObjectiveFromL1Method    RequestMethod = "get_l2_objective_from_l1"
-	GetL2ChannelFromL1Method      RequestMethod = "get_l2_channel_from_l1"
 	GetPendingBridgeTxsMethod     RequestMethod = "get_pending_bridge_txs"
 
 	GetSignedStateMethod RequestMethod = "get_signed_state"
@@ -122,10 +121,6 @@ type GetL2ObjectiveFromL1Request struct {
 	L1ObjectiveId protocols.ObjectiveId
 }
 
-type GetL2ChannelFromL1Request struct {
-	L1ChannelId types.Destination
-}
-
 type GetPendingBridgeTxsRequest struct {
 	ChannelId types.Destination
 }
@@ -160,8 +155,7 @@ type RequestPayload interface {
 		RetryTxRequest |
 		GetObjectiveRequest |
 		GetL2ObjectiveFromL1Request |
-		GetPendingBridgeTxsRequest |
-		GetL2ChannelFromL1Request
+		GetPendingBridgeTxsRequest
 }
 
 type NotificationPayload interface {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -41,6 +41,7 @@ const (
 	// Bridge methods
 	GetAllL2ChannelsRequestMethod RequestMethod = "get_all_l2_channels"
 	GetL2ObjectiveFromL1Method    RequestMethod = "get_l2_objective_from_l1"
+	GetL2ChannelFromL1Method      RequestMethod = "get_l2_channel_from_l1"
 	GetPendingBridgeTxsMethod     RequestMethod = "get_pending_bridge_txs"
 
 	GetSignedStateMethod RequestMethod = "get_signed_state"
@@ -120,6 +121,10 @@ type GetL2ObjectiveFromL1Request struct {
 	L1ObjectiveId protocols.ObjectiveId
 }
 
+type GetL2ChannelFromL1Request struct {
+	L1ChannelId types.Destination
+}
+
 type GetPendingBridgeTxsRequest struct {
 	ChannelId types.Destination
 }
@@ -154,7 +159,8 @@ type RequestPayload interface {
 		RetryTxRequest |
 		GetObjectiveRequest |
 		GetL2ObjectiveFromL1Request |
-		GetPendingBridgeTxsRequest
+		GetPendingBridgeTxsRequest |
+		GetL2ChannelFromL1Request
 }
 
 type NotificationPayload interface {
@@ -200,7 +206,8 @@ type ResponsePayload interface {
 		payments.ReceiveVoucherSummary |
 		CounterChallengeRequest |
 		ValidateVoucherResponse |
-		types.NodeInfo
+		types.NodeInfo |
+		types.Destination
 }
 
 type JsonRpcSuccessResponse[T ResponsePayload] struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -58,6 +58,7 @@ const (
 	ObjectiveCompleted    NotificationMethod = "objective_completed"
 	LedgerChannelUpdated  NotificationMethod = "ledger_channel_updated"
 	PaymentChannelUpdated NotificationMethod = "payment_channel_updated"
+	MirrorChannelCreated  NotificationMethod = "mirror_channel_created"
 )
 
 type NotificationOrRequest interface {
@@ -166,7 +167,8 @@ type RequestPayload interface {
 type NotificationPayload interface {
 	protocols.ObjectiveId |
 		query.PaymentChannelInfo |
-		query.LedgerChannelInfo
+		query.LedgerChannelInfo |
+		types.Destination
 }
 
 type Params[T RequestPayload | NotificationPayload] struct {


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Add support to send notification for created mirror channel in bridge server
- Add `GetAddressMethod` method in bridge server
- Add steps in README to retry failed transactions