### PR TITLE
Fix `swapdefund` with multiple open swap channels

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -3,7 +3,9 @@ package consensus_channel
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"sort"
 
@@ -133,6 +135,13 @@ func (c *ConsensusChannel) IsProposed(g Guarantee, a common.Address) (bool, erro
 func (c *ConsensusChannel) IsProposedNext(g Guarantee, a common.Address) (bool, error) {
 	vars := Vars{TurnNum: c.current.TurnNum, Outcome: c.current.Outcome.clone()}
 
+	marshalledProposalQueue, er := json.Marshal(c.proposalQueue)
+	if er != nil {
+		slog.Debug("DEBUG: Error marshalling proposal queue inside IsProposedNext", "error", er)
+	} else {
+		slog.Debug("DEBUG: Inside is proposed next", "ProposalQueue", string(marshalledProposalQueue))
+	}
+
 	if len(c.proposalQueue) == 0 {
 		return false, nil
 	}
@@ -146,6 +155,8 @@ func (c *ConsensusChannel) IsProposedNext(g Guarantee, a common.Address) (bool, 
 	if err != nil {
 		return false, err
 	}
+
+	slog.Debug("DEBUG: Inside is proposed next", "isProposedNext", vars.Outcome.includes(g, a) && !c.Includes(g, a))
 
 	return vars.Outcome.includes(g, a) && !c.Includes(g, a), nil
 }

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -167,11 +167,11 @@ func (c *ConsensusChannel) IncludesTarget(target types.Destination) bool {
 }
 
 // HasRemovalBeenProposed returns whether or not a proposal exists to remove the guarantee for the target.
-func (c *ConsensusChannel) HasRemovalBeenProposed(target types.Destination) bool {
+func (c *ConsensusChannel) HasRemovalBeenProposed(target types.Destination, assetAddress common.Address) bool {
 	for _, p := range c.proposalQueue {
 		if p.Proposal.Type() == RemoveProposal {
 			remove := p.Proposal.ToRemove
-			if remove.Target == target {
+			if remove.Target == target && remove.AssetAddress == assetAddress {
 				return true
 			}
 		}
@@ -180,13 +180,13 @@ func (c *ConsensusChannel) HasRemovalBeenProposed(target types.Destination) bool
 }
 
 // HasRemovalBeenProposedNext returns whether or not the next proposal in the queue is a remove proposal for the given target
-func (c *ConsensusChannel) HasRemovalBeenProposedNext(target types.Destination) bool {
+func (c *ConsensusChannel) HasRemovalBeenProposedNext(target types.Destination, assetAddress common.Address) bool {
 	if len(c.proposalQueue) == 0 {
 		return false
 	}
 
 	p := c.proposalQueue[0]
-	return p.Proposal.Type() == RemoveProposal && p.Proposal.ToRemove.Target == target
+	return p.Proposal.Type() == RemoveProposal && p.Proposal.ToRemove.Target == target && p.Proposal.ToRemove.AssetAddress == assetAddress
 }
 
 // IsLeader returns true if the calling client is the leader of the channel,

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -137,9 +137,9 @@ func (c *ConsensusChannel) IsProposedNext(g Guarantee, a common.Address) (bool, 
 
 	marshalledProposalQueue, er := json.Marshal(c.proposalQueue)
 	if er != nil {
-		slog.Debug("DEBUG: Error marshalling proposal queue inside IsProposedNext", "error", er)
+		slog.Debug("DEBUG: consensus_channel.go-IsProposedNext error marshalling proposal queue", "error", er)
 	} else {
-		slog.Debug("DEBUG: Inside is proposed next", "ProposalQueue", string(marshalledProposalQueue))
+		slog.Debug("DEBUG: consensus_channel.go-IsProposedNext", "proposalQueue", string(marshalledProposalQueue))
 	}
 
 	if len(c.proposalQueue) == 0 {
@@ -156,7 +156,8 @@ func (c *ConsensusChannel) IsProposedNext(g Guarantee, a common.Address) (bool, 
 		return false, err
 	}
 
-	slog.Debug("DEBUG: Inside is proposed next", "isProposedNext", vars.Outcome.includes(g, a) && !c.Includes(g, a))
+	slog.Debug("DEBUG: consensus_channel.go-IsProposedNext is guarantee going to be included", "isGuranteeIncluded", vars.Outcome.includes(g, a))
+	slog.Debug("DEBUG: consensus_channel.go-IsProposedNext is guarantee already included", "isGuranteeIncluded", c.Includes(g, a))
 
 	return vars.Outcome.includes(g, a) && !c.Includes(g, a), nil
 }

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -392,8 +392,17 @@ func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 
 	}
 
+	slog.Debug("DEBUG: LedgerProposals via message", "Ledger proposals length", len(message.LedgerProposals))
+
 	for _, entry := range message.LedgerProposals { // The ledger protocol requires us to process these proposals in turnNum order.
 		// Here we rely on the sender having packed them into the message in that order, and do not apply any checks or sorting of our own.
+		marshalledProposal, er := json.Marshal(entry)
+		if er != nil {
+			slog.Debug("DEBUG: Error marshalling proposal in engine.handleMessage")
+		} else {
+			slog.Debug("DEBUG: Proposal received from message", "proposal", string(marshalledProposal))
+		}
+
 		c, _ := e.store.GetChannelById(entry.Proposal.Target())
 		id := getProposalObjectiveId(entry.Proposal, c.Type)
 

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -392,15 +392,15 @@ func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 
 	}
 
-	slog.Debug("DEBUG: LedgerProposals via message", "Ledger proposals length", len(message.LedgerProposals))
+	slog.Debug("DEBUG: engine.go-handleMessage length of ledger proposals via message", "length", len(message.LedgerProposals))
 
 	for _, entry := range message.LedgerProposals { // The ledger protocol requires us to process these proposals in turnNum order.
 		// Here we rely on the sender having packed them into the message in that order, and do not apply any checks or sorting of our own.
 		marshalledProposal, er := json.Marshal(entry)
 		if er != nil {
-			slog.Debug("DEBUG: Error marshalling proposal in engine.handleMessage")
+			slog.Debug("DEBUG: engine.go-handleMessage error marshalling proposal")
 		} else {
-			slog.Debug("DEBUG: Proposal received from message", "proposal", string(marshalledProposal))
+			slog.Debug("DEBUG: engine.go-handleMessage proposal received from message", "proposal", string(marshalledProposal))
 		}
 
 		c, _ := e.store.GetChannelById(entry.Proposal.Target())
@@ -1061,7 +1061,7 @@ func (e *Engine) generateNotifications(o protocols.Objective) (EngineEvent, erro
 				return outgoing, err
 			}
 
-			slog.Debug("DEBUG: Generating notification for payment_channel_updated")
+			slog.Debug("DEBUG: engine-generateNotifications generating notification for payment_channel_updated")
 			outgoing.PaymentChannelUpdates = append(outgoing.PaymentChannelUpdates, info)
 		case *channel.Channel:
 			l, err := query.ConstructLedgerInfoFromChannel(c, *e.store.GetAddress())

--- a/packages/nitro-protocol/tasks/check-balance.ts
+++ b/packages/nitro-protocol/tasks/check-balance.ts
@@ -30,5 +30,7 @@ export default task('check-token-balance', 'Prints the token balance of a given 
     const formattedBalance = ethers.utils.formatUnits(balance, decimals);
 
     // Print the token balance
-    console.log(`Balance of ${accountAddress}: ${formattedBalance} tokens`);
+    console.log(
+      `Balance of ${accountAddress}: ${formattedBalance} tokens with token address ${tokenAddress}`
+    );
   });

--- a/packages/nitro-protocol/tasks/transfer.ts
+++ b/packages/nitro-protocol/tasks/transfer.ts
@@ -22,5 +22,7 @@ export default task('transfer', 'Transfers ERC20 tokens')
     const tx = await token.transfer(recipient, parsedAmount);
     await tx.wait();
 
-    console.log(`Transferred ${amount} tokens to ${recipient} from ${sender.address}`);
+    console.log(
+      `Transferred ${amount} tokens with address ${contractAddress} to ${recipient} from ${sender.address}`
+    );
   });

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -120,7 +120,7 @@ export class NitroRpcClient implements RpcClientApi {
           if (payload.ID === channelId) {
             this.GetPaymentChannel(channelId).then((l) => {
               console.log(
-                "DEBUG: Payment channel status after payment_channel_updated notification",
+                "DEBUG: rpc-client.ts-WaitForPaymentChannelStatus payment channel status after payment_channel_updated notification",
                 l.Status
               );
               if (l.Status == status) resolve();

--- a/protocols/swapdefund/swapdefund.go
+++ b/protocols/swapdefund/swapdefund.go
@@ -425,7 +425,16 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 	var sideEffects protocols.SideEffects
 
 	proposals := o.ledgerProposal(ledger)
-	proposed := ledger.HasRemovalBeenProposed(o.VId())
+	proposed := false
+
+	for _, p := range proposals {
+		isProposed := ledger.HasRemovalBeenProposed(o.VId(), p.ToRemove.AssetAddress)
+
+		if isProposed {
+			proposed = true
+			break
+		}
+	}
 
 	if ledger.IsLeader() {
 		if proposed { // If we've already proposed a remove proposal we can return
@@ -450,7 +459,7 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 	} else {
 		// If the proposal is next in the queue we accept it
 		for _, p := range proposals {
-			proposedNext := ledger.HasRemovalBeenProposedNext(o.VId())
+			proposedNext := ledger.HasRemovalBeenProposedNext(o.VId(), p.ToRemove.AssetAddress)
 
 			if proposedNext {
 				sp, err := ledger.SignNextProposal(p, *sk)

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -420,7 +420,7 @@ func (o *Objective) ledgerProposal(ledger *consensus_channel.ConsensusChannel) c
 func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.ConsensusChannel, sk *[]byte) (protocols.SideEffects, error) {
 	var sideEffects protocols.SideEffects
 
-	proposed := ledger.HasRemovalBeenProposed(o.VId())
+	proposed := ledger.HasRemovalBeenProposed(o.VId(), o.ledgerProposal(ledger).ToRemove.AssetAddress)
 
 	if ledger.IsLeader() {
 		if proposed { // If we've already proposed a remove proposal we can return
@@ -441,7 +441,7 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 
 	} else {
 		// If the proposal is next in the queue we accept it
-		proposedNext := ledger.HasRemovalBeenProposedNext(o.VId())
+		proposedNext := ledger.HasRemovalBeenProposedNext(o.VId(), o.ledgerProposal(ledger).ToRemove.AssetAddress)
 		if proposedNext {
 			sp, err := ledger.SignNextProposal(o.ledgerProposal(ledger), *sk)
 			if err != nil {

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -101,7 +101,7 @@ func (c *Connection) IsFundingTheTarget() bool {
 	if err != nil {
 		fmt.Println(err)
 	} else {
-		slog.Debug("DEBUG: Expected guarantee", "guarantee", string(marshalledGuarantee), "isIncluded", c.Channel.Includes(g, a), "myIndex", c.Channel.MyIndex, "address", a)
+		slog.Debug("DEBUG: virtualfund.go-IsFundingTheTarget expected guarantee", "guarantee", string(marshalledGuarantee), "isIncluded", c.Channel.Includes(g, a), "myIndex", c.Channel.MyIndex, "address", a)
 	}
 
 	return c.Channel.Includes(g, a)
@@ -713,7 +713,7 @@ func (o *Objective) acceptLedgerUpdate(c Connection, sk *[]byte) (protocols.Side
 	}
 	sideEffects := protocols.SideEffects{}
 
-	slog.Debug("DEBUG: Proposal Queue length", "len", len(ledger.ProposalQueue()))
+	slog.Debug("DEBUG: virtualfund.go-acceptLedgerUpdate proposal queue length", "length", len(ledger.ProposalQueue()))
 
 	// ledger sideEffect
 	if proposals := ledger.ProposalQueue(); len(proposals) != 0 {
@@ -740,7 +740,7 @@ func (o *Objective) updateLedgerWithGuarantee(ledgerConnection Connection, sk *[
 		return protocols.SideEffects{}, err
 	}
 
-	slog.Debug("DEBUG: Is guarantee proposed", "isProposed", proposed)
+	slog.Debug("DEBUG: virtualfund.go-updateLedgerWithGuarantee is guarantee proposed", "isProposed", proposed)
 
 	if ledger.IsLeader() { // If the user is the proposer craft a new proposal
 		if proposed {

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -101,7 +101,7 @@ func (c *Connection) IsFundingTheTarget() bool {
 	if err != nil {
 		fmt.Println(err)
 	} else {
-		slog.Debug("DEBUG: Expected guarantee", "guarantee", string(marshalledGuarantee), "isIncluded", c.Channel.Includes(g, a), "myIndex", c.Channel.MyIndex)
+		slog.Debug("DEBUG: Expected guarantee", "guarantee", string(marshalledGuarantee), "isIncluded", c.Channel.Includes(g, a), "myIndex", c.Channel.MyIndex, "address", a)
 	}
 
 	return c.Channel.Includes(g, a)

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -353,7 +353,7 @@ func (rs *NodeRpcServer) sendNotifications(ctx context.Context,
 				return
 			}
 
-			slog.Debug("DEBUG: Sending payment_channel_updated notification")
+			slog.Debug("DEBUG: node_server.go-sendNotifications sending payment_channel_updated notification")
 			err := sendNotification(rs.BaseRpcServer, serde.PaymentChannelUpdated, paymentInfo)
 			if err != nil {
 				panic(err)

--- a/rpc/transport/http/server.go
+++ b/rpc/transport/http/server.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -105,11 +106,16 @@ func (t *serverHttpTransport) RegisterRequestHandler(apiVersion string, handler 
 }
 
 func (t *serverHttpTransport) Notify(data []byte) error {
-	slog.Debug("DEBUG: In http server Notify method")
+	slog.Debug("DEBUG: server.go-Notify")
 	t.notificationListeners.Range(func(key string, value chan []byte) bool {
 		value <- data
 
-		slog.Debug("DEBUG: Sent data to notification listeners", "key", key, "data", string(data))
+		marshalledData, err := json.Marshal(data)
+		if err != nil {
+			slog.Debug("DEBUG: server.go-Notify error marshalling data")
+		} else {
+			slog.Debug("DEBUG: server.go-Notify sent data to notification listeners", "key", key, "data", string(marshalledData))
+		}
 
 		return true
 	})


### PR DESCRIPTION
Part of [Swap channels in go-nitro](https://www.notion.so/Swap-channels-in-go-nitro-119a6b22d47280b9bcf4e339fa6ba5b4)
- Check for asset address while comparing remove proposals used to remove guarantee from ledger channel
- Update logs to debug `virtualfund` failing in deployed nitro-nodes on L2