### PR TITLE
Fix validation on `swap-initiate` command and `swapdefund` objective

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -437,6 +437,10 @@ func (n *Node) GetPendingSwapByChannelId(swapChannelId types.Destination) (*paym
 	return n.store.GetPendingSwapByChannelId(swapChannelId)
 }
 
+func (n *Node) GetRecentSwapsByChannelId(swapChannelId types.Destination) ([]payments.Swap, error) {
+	return n.store.GetSwapsByChannelId(swapChannelId)
+}
+
 func (n *Node) GetVoucher(id types.Destination) payments.Voucher {
 	var voucher payments.Voucher
 	voucherInfo, voucherFound := n.vm.GetVoucherIfAmountPresent(id)

--- a/node/node.go
+++ b/node/node.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/internal/safesync"
@@ -274,10 +275,15 @@ func (n *Node) SwapAssets(channelId types.Destination, tokenIn common.Address, t
 		return swap.ObjectiveResponse{}, err
 	}
 
+	myIndex, err := swap.MyIndexInAllocations(&channel.SwapChannel{Channel: *swapChannel})
+	if err != nil {
+		return swap.ObjectiveResponse{}, err
+	}
+
 	nonce := rand.Uint64()
 	newSwap := payments.NewSwap(channelId, tokenIn, tokenOut, amountIn, amountOut, nonce)
 
-	isSwapValid := swap.IsValidSwap(swapState, newSwap, swapChannel.MyIndex)
+	isSwapValid := swap.IsValidSwap(swapState, newSwap, myIndex)
 	if !isSwapValid {
 		return swap.ObjectiveResponse{}, swap.ErrInvalidSwap
 	}
@@ -524,7 +530,7 @@ func (n *Node) ConfirmSwap(swapId types.Destination, action types.SwapStatus) er
 		return fmt.Errorf("swap with ID %s is not approved", swapId.String())
 	}
 
-	myIndex, err := o.MyIndexInAllocations()
+	myIndex, err := swap.MyIndexInAllocations(o.C)
 	if err != nil {
 		return err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -256,7 +256,7 @@ func (n *Node) CreatePaymentChannel(Intermediaries []types.Address, CounterParty
 }
 
 func (n *Node) SwapAssets(channelId types.Destination, tokenIn common.Address, tokenOut common.Address, amountIn *big.Int, amountOut *big.Int) (swap.ObjectiveResponse, error) {
-	swapChannel, ok := n.store.GetChannelById(channelId)
+	ch, ok := n.store.GetChannelById(channelId)
 	if !ok {
 		return swap.ObjectiveResponse{}, fmt.Errorf("no swap channel found for channel ID %v", channelId)
 	}
@@ -270,12 +270,10 @@ func (n *Node) SwapAssets(channelId types.Destination, tokenIn common.Address, t
 		return swap.ObjectiveResponse{}, fmt.Errorf("%w: channel Id %+v", swap.ErrSwapExists, channelId)
 	}
 
-	swapState, err := swapChannel.LatestSupportedState()
-	if err != nil {
-		return swap.ObjectiveResponse{}, err
-	}
+	swapChannel := &channel.SwapChannel{Channel: *ch}
+	swapState := swapChannel.LatestSupportedSwapChannelState()
 
-	myIndex, err := swap.MyIndexInAllocations(&channel.SwapChannel{Channel: *swapChannel})
+	myIndex, err := swap.MyIndexInAllocations(swapChannel)
 	if err != nil {
 		return swap.ObjectiveResponse{}, err
 	}

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -826,6 +826,33 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
+    "get-recent-swaps <channelId>",
+    "Gets recent swaps for this swap channel",
+    (yargsBuilder) => {
+      return yargsBuilder.positional("channelId", {
+        describe: "The channel ID of the payment channel",
+        type: "string",
+        demandOption: true,
+      });
+    },
+    async (yargs) => {
+      const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
+      const isSecure = yargs.s;
+
+      const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
+        getRPCUrl(rpcHost, rpcPort),
+        isSecure
+      );
+
+      // TODO: Generate JSON schema for get current swap
+      const recentSwaps = await rpcClient.GetRecentSwaps(yargs.channelId);
+      console.log(JSON.parse(recentSwaps));
+      await rpcClient.Close();
+      process.exit(0);
+    }
+  )
+  .command(
     "swap-initiate <channelId>",
     "Swaps assets on a given swap channel",
     (yargsBuilder) => {

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -215,6 +215,13 @@ export class NitroRpcClient implements RpcClientApi {
     return this.sendRequest("get_pending_swap", payload);
   }
 
+  public async GetRecentSwaps(channelId: string): Promise<string> {
+    const payload = {
+      Id: channelId,
+    };
+    return this.sendRequest("get_recent_swaps", payload);
+  }
+
   public async CreatePaymentChannel(
     counterParty: string,
     intermediaries: string[],

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -260,6 +260,7 @@ export function getAndValidateResult<T extends RequestMethod>(
     case "close_payment_channel":
     case "close_swap_channel":
     case "get_pending_swap":
+    case "get_recent_swaps":
       return validateAndConvertResult(
         stringSchema,
         result,

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -223,6 +223,12 @@ export type GetPendingSwapRequest = JsonRpcRequest<
   "get_pending_swap",
   GetPendingSwap
 >;
+export type GetRecentSwapsRequest = JsonRpcRequest<
+  "get_recent_swaps",
+  {
+    Id: string;
+  }
+>;
 export type GetPaymentChannelsByLedgerRequest = JsonRpcRequest<
   "get_payment_channels_by_ledger",
   GetByLedgerRequest
@@ -293,6 +299,7 @@ export type GetPaymentChannelResponse = JsonRpcResponse<PaymentChannelInfo>;
 export type GetSwapChannelResponse = JsonRpcResponse<SwapChannelInfo>;
 export type GetVoucherResponse = JsonRpcResponse<Voucher>;
 export type GetPendingSwapResponse = JsonRpcResponse<string>;
+export type GetRecentSwapsResponse = JsonRpcResponse<string>;
 export type PaymentResponse = JsonRpcResponse<PaymentPayload>;
 export type SwapResponse = JsonRpcResponse<SwapInitiatePayload>;
 export type CounterChallengeResponse = JsonRpcResponse<CounterChallengeResult>;
@@ -346,6 +353,7 @@ export type RPCRequestAndResponses = {
   get_swap_channel: [GetSwapChannelRequest, GetSwapChannelResponse];
   get_voucher: [GetVoucherRequest, GetVoucherResponse];
   get_pending_swap: [GetPendingSwapRequest, GetPendingSwapResponse];
+  get_recent_swaps: [GetRecentSwapsRequest, GetRecentSwapsResponse];
   pay: [PaymentRequest, PaymentResponse];
   swap_initiate: [SwapRequest, SwapResponse];
   confirm_swap: [ConfirmSwapRequest, ConfirmSwapResponse];

--- a/protocols/swap/swap.go
+++ b/protocols/swap/swap.go
@@ -89,7 +89,7 @@ func NewObjective(request ObjectiveRequest, preApprove bool, isSwapSender bool, 
 }
 
 func (o *Objective) determineSwapSenderIndex(isSwapSender bool) (uint, error) {
-	myIndex, err := o.MyIndexInAllocations()
+	myIndex, err := MyIndexInAllocations(o.C)
 	if err != nil {
 		return 0, err
 	}
@@ -239,7 +239,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		return &updated, sideEffects, WaitingForNothing, protocols.ErrNotApproved
 	}
 
-	myIndex, err := o.MyIndexInAllocations()
+	myIndex, err := MyIndexInAllocations(o.C)
 	if err != nil {
 		return &updated, sideEffects, WaitingForNothing, err
 	}
@@ -556,9 +556,9 @@ func (o *Objective) counterPartyAddress() common.Address {
 	return o.C.Participants[counterPartyIndex]
 }
 
-func (o *Objective) MyIndexInAllocations() (uint, error) {
-	myAddress := o.C.Participants[o.C.MyIndex]
-	state, _ := o.C.LatestSupportedState()
+func MyIndexInAllocations(c *channel.SwapChannel) (uint, error) {
+	myAddress := c.Participants[c.MyIndex]
+	state, _ := c.LatestSupportedState()
 	for i, allocation := range state.Outcome[0].Allocations {
 		if allocation.Destination == types.AddressToDestination(myAddress) {
 			return uint(i), nil

--- a/protocols/swapdefund/swapdefund.go
+++ b/protocols/swapdefund/swapdefund.go
@@ -536,46 +536,40 @@ func getRequestFinalStatePayload(b []byte) (types.Destination, error) {
 	return cId, nil
 }
 
-// TODO: Use virtual defund validation pattern
-// TODO: Fix intermediary validation
 // isSignedStateValidForIntermediary checks if the signed state in the incoming message is valid for the intermediary
-// func (o *Objective) isSignedStateValidForIntermediary(ss state.SignedState) (bool, error) {
-// 	existingSwapChannelSignedState, err := o.S.LatestSupportedSignedState()
-// 	if err != nil {
-// 		return false, err
-// 	}
+func isSignedStateValidForIntermediary(existingSwapChannelSignedState, incomingSwapChannelState state.SignedState) (bool, error) {
+	if incomingSwapChannelState.ChannelId() != existingSwapChannelSignedState.ChannelId() {
+		return false, fmt.Errorf("channel ID mismatch: expected %s, got %s", existingSwapChannelSignedState.ChannelId(), incomingSwapChannelState.ChannelId())
+	}
 
-// 	if ss.ChannelId() != existingSwapChannelSignedState.ChannelId() {
-// 		return false, fmt.Errorf("channel ID mismatch: expected %s, got %s", existingSwapChannelSignedState.ChannelId(), ss.ChannelId())
-// 	}
+	existingSwapChannelState := existingSwapChannelSignedState.State().Clone()
+	incomingOutcomes := incomingSwapChannelState.State().Outcome.Clone()
+	for i, exisingOutcome := range existingSwapChannelState.Outcome {
+		incomingOutcome := incomingOutcomes[i]
+		if !isAssetOutcomeValidForIntermediary(exisingOutcome, incomingOutcome) {
+			return false, fmt.Errorf("invalid outcome in incoming signed state")
+		}
+	}
 
-// 	incomingOutcomes := ss.State().Outcome
-// 	for i, exisingOutcome := range existingSwapChannelSignedState.State().Outcome {
-// 		incomingOutcome := incomingOutcomes[i]
-// 		if !isAssetOutcomeValidForIntermediary(exisingOutcome, incomingOutcome) {
-// 			return false, fmt.Errorf("invalid outcome in incoming signed state")
-// 		}
-// 	}
+	return true, nil
+}
 
-// 	return true, nil
-// }
+func isAssetOutcomeValidForIntermediary(existingOutcome, incomingOutcome outcome.SingleAssetExit) bool {
+	if existingOutcome.Asset != incomingOutcome.Asset && existingOutcome.AssetMetadata.AssetType != incomingOutcome.AssetMetadata.AssetType {
+		return false
+	}
 
-// func isAssetOutcomeValidForIntermediary(existingOutcome, incomingOutcome outcome.SingleAssetExit) bool {
-// 	if existingOutcome.Asset != incomingOutcome.Asset && existingOutcome.AssetMetadata.AssetType != incomingOutcome.AssetMetadata.AssetType {
-// 		return false
-// 	}
+	existingAllocationAmountTotal := new(big.Int)
+	incomingAllocationAmountTotal := new(big.Int)
 
-// 	existingAllocationAmountTotal := common.Big0
-// 	incomingAllocationAmountTotal := common.Big0
+	for i, existingAllocation := range existingOutcome.Allocations {
+		incomingAllocation := incomingOutcome.Allocations[i]
+		existingAllocationAmountTotal.Add(existingAllocationAmountTotal, existingAllocation.Amount)
+		incomingAllocationAmountTotal.Add(incomingAllocationAmountTotal, incomingAllocation.Amount)
+	}
 
-// 	for i, existingAllocation := range existingOutcome.Allocations {
-// 		incomingAllocation := incomingOutcome.Allocations[i]
-// 		existingAllocationAmountTotal = existingAllocationAmountTotal.Add(existingAllocationAmountTotal, existingAllocation.Amount)
-// 		incomingAllocationAmountTotal = incomingAllocationAmountTotal.Add(incomingAllocationAmountTotal, incomingAllocation.Amount)
-// 	}
-
-// 	return existingAllocationAmountTotal == incomingAllocationAmountTotal
-// }
+	return existingAllocationAmountTotal.Cmp(incomingAllocationAmountTotal) == 0
+}
 
 // Update receives an protocols.ObjectiveEvent, applies all applicable event data to the SwapDefundObjective,
 // and returns the updated state.
@@ -592,17 +586,19 @@ func (o *Objective) Update(op protocols.ObjectivePayload) (protocols.Objective, 
 		}
 		updated := o.clone()
 
-		// TODO: Check signed state validation in virtual defund
 		if updated.FinalTurnNum == channel.PostFundTurnNum {
-			// TODO: Fix intermediary validation
-			// ok, err := o.isSignedStateValidForIntermediary(ss.Clone())
-			// if err != nil {
-			// 	return &Objective{}, fmt.Errorf("failed to validate signed state for intermediary participant: %w", err)
-			// }
+			existingSwapChannelSignedState, err := updated.S.LatestSupportedSignedState()
+			if err != nil {
+				return &Objective{}, err
+			}
+			ok, err := isSignedStateValidForIntermediary(existingSwapChannelSignedState, ss)
+			if err != nil {
+				return &Objective{}, fmt.Errorf("failed to validate signed state for intermediary participant: %w", err)
+			}
 
-			// if !ok {
-			// 	return &Objective{}, fmt.Errorf("invalid signed state for intermediary participant")
-			// }
+			if !ok {
+				return &Objective{}, fmt.Errorf("invalid signed state for intermediary participant")
+			}
 
 			updated.FinalTurnNum = ss.State().TurnNum
 		}

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -196,6 +196,20 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 
 				return string(swapJson), nil
 			})
+		case serde.GetRecentSwapsRequestMethod:
+			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.GetSwapChannelRequest) (string, error) {
+				swaps, err := nrs.node.GetRecentSwapsByChannelId(req.Id)
+				if err != nil {
+					return "", err
+				}
+
+				swapJson, err := json.Marshal(swaps)
+				if err != nil {
+					return "", err
+				}
+
+				return string(swapJson), nil
+			})
 		case serde.PayRequestMethod:
 			return processRequest(nrs.BaseRpcServer, permSign, requestData, func(req serde.PaymentRequest) (serde.PaymentRequest, error) {
 				if err := serde.ValidatePaymentRequest(req); err != nil {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -41,6 +41,7 @@ const (
 	GetAllLedgerChannelsMethod        RequestMethod = "get_all_ledger_channels"
 	GetNodeInfoRequestMethod          RequestMethod = "get_node_info"
 	GetPendingSwapRequestMethod       RequestMethod = "get_pending_swap"
+	GetRecentSwapsRequestMethod       RequestMethod = "get_recent_swaps"
 	CreateVoucherRequestMethod        RequestMethod = "create_voucher"
 	ReceiveVoucherRequestMethod       RequestMethod = "receive_voucher"
 	CounterChallengeRequestMethod     RequestMethod = "counter_challenge"


### PR DESCRIPTION
Part of [Swap channels in go-nitro](https://www.notion.so/Swap-channels-in-go-nitro-119a6b22d47280b9bcf4e339fa6ba5b4)
- Fix validation while initiating swaps in `swapAssets` method
- Add test to perform swaps with equal asset amounts
- Fix validation of the incoming swap channel state for intermediary in `swapdefund`
- Add CLI to get recent swaps