### PR TITLE
Handle race condition on sending swaps simultaneously

### DIFF
--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -40,7 +40,10 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-var errEmptyDroppedEvent error = errors.New("no dropped events yet")
+var (
+	errEmptyDroppedEvent   error = errors.New("no dropped events yet")
+	errSwapObjectiveExists error = errors.New("swap objective already exists")
+)
 
 // ErrUnhandledChainEvent is an engine error when the the engine cannot process a chain event
 type ErrUnhandledChainEvent struct {
@@ -71,6 +74,7 @@ var nonFatalErrors = []error{
 	swapfund.ErrUpdatingLedgerFunding,
 	swapfund.ErrZeroFunds,
 	errEmptyDroppedEvent,
+	errSwapObjectiveExists,
 	swap.ErrInvalidSwap,
 }
 
@@ -769,7 +773,7 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 		}
 
 		if pendingSwap != nil {
-			return failedEngineEvent, fmt.Errorf("objective already exists")
+			return failedEngineEvent, errSwapObjectiveExists
 		}
 		return e.attemptProgress(&so)
 

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -1519,10 +1519,14 @@ func (e *Engine) rejectSwapIfPendingExists(currentSwapObjective *swap.Objective)
 		return nil, err
 	}
 
+	slog.Debug("DEBUG: engine.go-rejectObjective", "currentHash", currentHash.String(), "myIndex", swapChannel.MyIndex)
+
 	pendingHash, err := pendingSwapWithSender.Hash()
 	if err != nil {
 		return nil, err
 	}
+
+	slog.Debug("DEBUG: engine.go-rejectObjective", "pendingHash", currentHash.String(), "myIndex", swapChannel.MyIndex)
 
 	// Do not enter if pending swap and current swap are same and this node is not the swap channel leader
 	if pendingSwap != nil && strings.Compare(pendingHash.String(), currentHash.String()) != 0 && swapChannel.MyIndex == 0 {

--- a/node/notifier/listeners.go
+++ b/node/notifier/listeners.go
@@ -29,9 +29,6 @@ func newSwapListeners() *swapListeners {
 func (li *swapListeners) Notify(info query.SwapInfo) {
 	li.listenersLock.Lock()
 	defer li.listenersLock.Unlock()
-	if li.prev.Id == info.Id && li.prev.ChannelId == info.ChannelId {
-		return
-	}
 
 	for _, list := range li.listeners {
 		list <- info

--- a/node/notifier/listeners.go
+++ b/node/notifier/listeners.go
@@ -29,6 +29,9 @@ func newSwapListeners() *swapListeners {
 func (li *swapListeners) Notify(info query.SwapInfo) {
 	li.listenersLock.Lock()
 	defer li.listenersLock.Unlock()
+	if li.prev.Id == info.Id && li.prev.ChannelId == info.ChannelId {
+		return
+	}
 
 	for _, list := range li.listeners {
 		list <- info

--- a/node_test/swap_test.go
+++ b/node_test/swap_test.go
@@ -389,6 +389,7 @@ func TestParallelSwaps(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Try to confirm both swaps and assert that one of them passes and one of them fails
 		var nodeBErr, nodeAErr error
 		if nodeAPendingSwap.Id == swapInfoFromNodeA.Id {
 			t.Log("Pending swap from node A")
@@ -401,7 +402,6 @@ func TestParallelSwaps(t *testing.T) {
 			nodeBErr = utils.nodeB.ConfirmSwap(swapInfoFromNodeA.Id, types.Accepted)
 		}
 
-		// Try to confirm both swaps and assert that one of them passes and one of them fails
 		var objToWaitFor protocols.ObjectiveId
 		nilErrs := 0
 		var errorsArr []error

--- a/payments/swaps.go
+++ b/payments/swaps.go
@@ -165,6 +165,41 @@ func (s *Swap) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+type SwapWithSender struct {
+	Swap   Swap
+	Sender common.Address
+}
+
+func (s SwapWithSender) encode() (types.Bytes, error) {
+	return ethAbi.Arguments{
+		{Type: abi.Destination}, // channel id
+		{Type: abi.Address},     // tokenIn
+		{Type: abi.Address},     // tokenOut
+		{Type: abi.Uint256},     // amountIn
+		{Type: abi.Uint256},     // amountOut
+		{Type: abi.Uint256},     // nonce
+		{Type: abi.Address},     // swap sender address
+	}.Pack(
+		s.Swap.ChannelId,
+		s.Swap.Exchange.TokenIn,
+		s.Swap.Exchange.TokenOut,
+		s.Swap.Exchange.AmountIn,
+		s.Swap.Exchange.AmountOut,
+		new(big.Int).SetUint64(s.Swap.Nonce),
+		s.Sender,
+	)
+}
+
+// Hash returns the keccak256 hash of the State
+func (s SwapWithSender) Hash() (types.Bytes32, error) {
+	encoded, err := s.encode()
+	if err != nil {
+		return types.Bytes32{}, fmt.Errorf("failed to encode swap: %w", err)
+	}
+
+	return crypto.Keccak256Hash(encoded), nil
+}
+
 type Exchange struct {
 	TokenIn   common.Address
 	TokenOut  common.Address


### PR DESCRIPTION
Part of [Swap channels in go-nitro](https://www.notion.so/Swap-channels-in-go-nitro-119a6b22d47280b9bcf4e339fa6ba5b4)
- If two swaps are sent simultaneously, order the swaps by comparing hash of ID and sender address
  - Reject the swap which has lexically lower hash
- Update test case to test parallel swaps scenario