### PR TITLE
Add CLI method to get all swap channels by ledger ID

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_RUNNER_DEBUG: true
+      ACTIONS_STEP_DEBUG: true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -135,7 +135,7 @@ func (b *Bridge) Start(configOpts BridgeConfig) (nodeL1 *node.Node, nodeL2 *node
 		return nil, nil, nodeL1MultiAddress, nodeL2MultiAddress, err
 	}
 
-	nodeL2, storeL2, msgServiceL2, chainServiceL2, err := nodeutils.InitializeL2Node(chainOptsL2, storeOptsL2, messageOptsL2)
+	nodeL2, storeL2, msgServiceL2, chainServiceL2, err := nodeutils.InitializeL2Node(chainOptsL2, storeOptsL2, messageOptsL2, &NodeL2PermissivePolicy{})
 	if err != nil {
 		return nil, nil, nodeL1MultiAddress, nodeL2MultiAddress, err
 	}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -210,17 +210,6 @@ func (b *Bridge) processCompletedObjectivesFromL1(objId protocols.ObjectiveId) e
 		return err
 	}
 
-	// Check if L2 node exists, if not then defund the L1 ledger channel
-	err = b.messageServiceL2.Ping(context.Background(), l1LedgerChannel.Leader().Hex())
-	if err != nil {
-		slog.Error(err.Error())
-		slog.Info("Node L2 not found, defunding L1 ledger channel")
-
-		_, err := b.nodeL1.CloseLedgerChannel(channelId, false)
-
-		return err
-	}
-
 	slog.Debug("Creating mirror outcome for L2", "channelId", channelId)
 	l1ledgerChannelState := l1LedgerChannel.SupportedSignedState()
 	l1ledgerChannelStateClone := l1ledgerChannelState.Clone()

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -210,6 +210,17 @@ func (b *Bridge) processCompletedObjectivesFromL1(objId protocols.ObjectiveId) e
 		return err
 	}
 
+	// Check if L2 node exists, if not then defund the L1 ledger channel
+	err = b.messageServiceL2.Ping(context.Background(), l1LedgerChannel.Leader().Hex())
+	if err != nil {
+		slog.Error(err.Error())
+		slog.Info("Node L2 not found, defunding L1 ledger channel")
+
+		_, err := b.nodeL1.CloseLedgerChannel(channelId, false)
+
+		return err
+	}
+
 	slog.Debug("Creating mirror outcome for L2", "channelId", channelId)
 	l1ledgerChannelState := l1LedgerChannel.SupportedSignedState()
 	l1ledgerChannelStateClone := l1ledgerChannelState.Clone()

--- a/bridge/policy_maker.go
+++ b/bridge/policy_maker.go
@@ -4,6 +4,8 @@ import (
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
+	"github.com/statechannels/go-nitro/protocols/swapdefund"
+	"github.com/statechannels/go-nitro/protocols/swapfund"
 	"github.com/statechannels/go-nitro/protocols/virtualdefund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 )
@@ -15,7 +17,7 @@ type (
 
 func (pp *NodeL1PermissivePolicy) ShouldApprove(o protocols.Objective) bool {
 	// L1 node rejects objectives if they involve virtual funding, virtual defunding, or direct defunding
-	if virtualfund.IsVirtualFundObjective(o.Id()) || virtualdefund.IsVirtualDefundObjective(o.Id()) || directdefund.IsDirectDefundObjective(o.Id()) {
+	if virtualfund.IsVirtualFundObjective(o.Id()) || virtualdefund.IsVirtualDefundObjective(o.Id()) || directdefund.IsDirectDefundObjective(o.Id()) || swapfund.IsSwapFundObjective(o.Id()) || swapdefund.IsSwapDefundObjective(o.Id()) {
 		return false
 	}
 
@@ -24,7 +26,7 @@ func (pp *NodeL1PermissivePolicy) ShouldApprove(o protocols.Objective) bool {
 
 func (pp *NodeL2PermissivePolicy) ShouldApprove(o protocols.Objective) bool {
 	// L2 node rejects objectives if they involve direct funding
-	if directfund.IsDirectFundObjective(o.Id()) {
+	if directfund.IsDirectFundObjective(o.Id()) || directdefund.IsDirectDefundObjective(o.Id()) {
 		return false
 	}
 

--- a/bridge/policy_maker.go
+++ b/bridge/policy_maker.go
@@ -3,15 +3,28 @@ package bridge
 import (
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
+	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/protocols/virtualdefund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 )
 
-type NodeL1PermissivePolicy struct{}
+type (
+	NodeL1PermissivePolicy struct{}
+	NodeL2PermissivePolicy struct{}
+)
 
 func (pp *NodeL1PermissivePolicy) ShouldApprove(o protocols.Objective) bool {
 	// L1 node rejects objectives if they involve virtual funding, virtual defunding, or direct defunding
 	if virtualfund.IsVirtualFundObjective(o.Id()) || virtualdefund.IsVirtualDefundObjective(o.Id()) || directdefund.IsDirectDefundObjective(o.Id()) {
+		return false
+	}
+
+	return o.GetStatus() == protocols.Unapproved
+}
+
+func (pp *NodeL2PermissivePolicy) ShouldApprove(o protocols.Objective) bool {
+	// L2 node rejects objectives if they involve direct funding
+	if directfund.IsDirectFundObjective(o.Id()) {
 		return false
 	}
 

--- a/internal/node/bridge.go
+++ b/internal/node/bridge.go
@@ -11,7 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/node/engine/store"
 )
 
-func InitializeL2Node(chainOpts chainservice.LaconicdChainOpts, storeOpts store.StoreOpts, messageOpts p2pms.MessageOpts) (*node.Node, *store.Store, *p2pms.P2PMessageService, chainservice.ChainService, error) {
+func InitializeL2Node(chainOpts chainservice.LaconicdChainOpts, storeOpts store.StoreOpts, messageOpts p2pms.MessageOpts, policymaker engine.PolicyMaker) (*node.Node, *store.Store, *p2pms.P2PMessageService, chainservice.ChainService, error) {
 	ourStore, err := store.NewStore(storeOpts)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -31,7 +31,7 @@ func InitializeL2Node(chainOpts chainservice.LaconicdChainOpts, storeOpts store.
 		messageService,
 		ourChain,
 		ourStore,
-		&engine.PermissivePolicy{},
+		policymaker,
 	)
 
 	return &node, &ourStore, messageService, ourChain, nil

--- a/main.go
+++ b/main.go
@@ -274,7 +274,7 @@ func main() {
 					VpaAddress: common.HexToAddress(vpaAddress),
 					CaAddress:  common.HexToAddress(caAddress),
 				}
-				node, _, _, _, err = nodeUtils.InitializeL2Node(chainOpts, storeOpts, messageOpts)
+				node, _, _, _, err = nodeUtils.InitializeL2Node(chainOpts, storeOpts, messageOpts, &engine.PermissivePolicy{})
 			} else {
 				chainOpts := chainservice.ChainOpts{
 					ChainUrl:           chainUrl,

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -76,6 +76,8 @@ var nonFatalErrors = []error{
 	errEmptyDroppedEvent,
 	errSwapObjectiveExists,
 	swap.ErrInvalidSwap,
+	types.ErrLeftLedgerChannelNotFound,
+	types.ErrRightLedgerChannelNotFound,
 }
 
 // Engine is the imperative part of the core business logic of a go-nitro Node

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -460,3 +460,11 @@ func (ms *P2PMessageService) connectBootPeers(bootPeers []peer.AddrInfo) {
 		}
 	}
 }
+
+func (ms *P2PMessageService) Ping(ctx context.Context, scAddr string) error {
+	p, err := ms.getPeerIdFromDht(scAddr)
+	if err != nil {
+		return err
+	}
+	return ms.dht.Ping(ctx, p)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -434,8 +434,14 @@ func (n *Node) GetPaymentChannel(id types.Destination) (query.PaymentChannelInfo
 	return query.GetPaymentChannelInfo(id, n.store, n.vm)
 }
 
+// GetSwapChannel returns the swap channel with the given id.
 func (n *Node) GetSwapChannel(id types.Destination) (string, error) {
 	return query.GetSwapChannelInfo(id, n.store)
+}
+
+// GetSwapChannelsByLedger returns all active swap channels that are funded by the given ledger channel.
+func (n *Node) GetSwapChannelsByLedger(ledgerId types.Destination) ([]query.SwapChannelInfo, error) {
+	return query.GetSwapChannelsByLedger(ledgerId, n.store)
 }
 
 // GetPaymentChannelsByLedger returns all active payment channels that are funded by the given ledger channel.

--- a/node/node.go
+++ b/node/node.go
@@ -367,7 +367,7 @@ func (n *Node) CreateBridgeChannel(Counterparty types.Address, ChallengeDuration
 	)
 
 	// Check store to see if there is an existing channel with this counterparty
-	channelExists, err := bridgedfund.ChannelsExistWithCounterparty(Counterparty, n.store.GetChannelsByParticipant, n.store.GetConsensusChannel)
+	channelExists, err := bridgedfund.OpenLedgerChannelsExistWithCounterparty(Counterparty, n.store.GetChannelsByParticipant, n.store.GetConsensusChannel)
 	if err != nil {
 		slog.Error("bridge fund error", "error", err)
 		return bridgedfund.ObjectiveResponse{}, fmt.Errorf("counterparty check failed: %w", err)

--- a/node/node.go
+++ b/node/node.go
@@ -502,13 +502,16 @@ func (n *Node) Close() error {
 	if err := n.engine.Close(); err != nil {
 		return err
 	}
+	slog.Debug("DEBUG: node.go-close closed engine")
 	if err := n.channelNotifier.Close(); err != nil {
 		return err
 	}
+	slog.Debug("DEBUG: node.go-close closed channelNotifier")
 
 	if err := n.completedObjectivesNotifier.Close(); err != nil {
 		return err
 	}
+	slog.Debug("DEBUG: node.go-close closed completedObjectivesNotifier")
 
 	return n.store.Close()
 }

--- a/node_test/swap_test.go
+++ b/node_test/swap_test.go
@@ -379,11 +379,14 @@ func TestParallelSwaps(t *testing.T) {
 		}
 
 		swapInfoFromNodeA := <-nodeASwapUpdates
+		t.Log("Received swap info from node A")
 		swapInfoFromNodeB := <-nodeBSwapUpdates
+		t.Log("Received swap info from node B")
 
 		// Wait for swap channel leader (node A) to make a decision (Which swap to accept and which one to reject)
 		// The rejected objective will be completed
 		<-nodeBCompletedObjectives
+		t.Log("Received info for completed objectives in node B")
 
 		nodeAPendingSwap, err := utils.nodeA.GetPendingSwapByChannelId(nodeASwapAssetResponse.ChannelId)
 		if err != nil {
@@ -420,7 +423,9 @@ func TestParallelSwaps(t *testing.T) {
 		testhelpers.Assert(t, errors.Is(errToCheck, store.ErrNoSuchSwap), "Incorrect error")
 
 		<-nodeACompletedObjectives
+		t.Log("Completed objectives in node A")
 		<-nodeBCompletedObjectives
+		t.Log("Completed objectives in node B")
 	})
 }
 

--- a/node_test/swap_test.go
+++ b/node_test/swap_test.go
@@ -89,20 +89,29 @@ func initializeNodesAndInfra(t *testing.T) (TestUtils, func()) {
 	}
 
 	cleanup := func() {
-		removeTempFolder()
-		t.Log("DEBUG: Removed temporary storage folder")
-
-		nodeB.Close()
+		err := nodeB.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Log("DEBUG: Closed node B")
 
-		nodeC.Close()
+		err = nodeC.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Log("DEBUG: Closed node C")
 
-		nodeA.Close()
+		err = nodeA.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Log("DEBUG: Closed node A")
 
 		infra.Close(t)
 		t.Log("DEBUG: Closed infra")
+
+		removeTempFolder()
+		t.Log("DEBUG: Removed temporary storage folder")
 	}
 
 	return utils, cleanup

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -6,6 +6,7 @@ import { readFileSync, writeFileSync } from "fs";
 
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
+import JSONbig from "json-bigint";
 
 import { NitroRpcClient } from "./rpc-client";
 import {
@@ -758,6 +759,37 @@ yargs(hideBin(process.argv))
       );
       const swapChannelInfo = await rpcClient.GetSwapChannel(yargs.channelId);
       console.log(swapChannelInfo);
+      await rpcClient.Close();
+      process.exit(0);
+    }
+  )
+  .command(
+    "get-swap-channels-by-ledger <ledgerId>",
+    "Gets any swap channels funded by the given ledger",
+    (yargsBuilder) => {
+      return yargsBuilder.positional("ledgerId", {
+        describe: "The ID of the ledger channel",
+        type: "string",
+        demandOption: true,
+      });
+    },
+
+    async (yargs) => {
+      const rpcPort = yargs.p;
+      const rpcHost = yargs.h;
+      const isSecure = yargs.s;
+
+      const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
+        getRPCUrl(rpcHost, rpcPort),
+        isSecure
+      );
+      const swapChannels = await rpcClient.GetSwapChannelsByLedger(
+        yargs.ledgerId
+      );
+
+      const parsedData = JSONbig.parse(swapChannels);
+      console.log(prettyJson(parsedData));
+
       await rpcClient.Close();
       process.exit(0);
     }

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -6,7 +6,6 @@ import { readFileSync, writeFileSync } from "fs";
 
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
-import JSONbig from "json-bigint";
 
 import { NitroRpcClient } from "./rpc-client";
 import {
@@ -787,8 +786,7 @@ yargs(hideBin(process.argv))
         yargs.ledgerId
       );
 
-      const parsedData = JSONbig.parse(swapChannels);
-      console.log(prettyJson(parsedData));
+      console.log(swapChannels);
 
       await rpcClient.Close();
       process.exit(0);

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -381,6 +381,12 @@ export class NitroRpcClient implements RpcClientApi {
     });
   }
 
+  public async GetSwapChannelsByLedger(ledgerId: string): Promise<string> {
+    return this.sendRequest("get_swap_channels_by_ledger", {
+      LedgerId: ledgerId,
+    });
+  }
+
   public async GetObjective(objectiveId: string, l2: boolean): Promise<string> {
     return this.sendRequest("get_objective", {
       ObjectiveId: objectiveId,

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -381,7 +381,9 @@ export class NitroRpcClient implements RpcClientApi {
     });
   }
 
-  public async GetSwapChannelsByLedger(ledgerId: string): Promise<string> {
+  public async GetSwapChannelsByLedger(
+    ledgerId: string
+  ): Promise<SwapChannelInfo[]> {
     return this.sendRequest("get_swap_channels_by_ledger", {
       LedgerId: ledgerId,
     });

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -261,6 +261,7 @@ export function getAndValidateResult<T extends RequestMethod>(
     case "close_swap_channel":
     case "get_pending_swap":
     case "get_recent_swaps":
+    case "get_swap_channels_by_ledger":
       return validateAndConvertResult(
         stringSchema,
         result,

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -234,6 +234,11 @@ export type GetPaymentChannelsByLedgerRequest = JsonRpcRequest<
   GetByLedgerRequest
 >;
 
+export type GetSwapChannelsByLedgerRequest = JsonRpcRequest<
+  "get_swap_channels_by_ledger",
+  GetByLedgerRequest
+>;
+
 export type GetObjectiveRequest = JsonRpcRequest<
   "get_objective",
   {
@@ -323,6 +328,7 @@ export type GetSignedStateResponse = JsonRpcResponse<string>;
 export type GetPaymentChannelsByLedgerResponse = JsonRpcResponse<
   PaymentChannelInfo[]
 >;
+export type GetSwapChannelsByLedgerResponse = JsonRpcResponse<string>;
 export type GetObjectiveResponse = JsonRpcResponse<string>;
 export type GetL2ObjectiveFromL1Response = JsonRpcResponse<string>;
 export type GetPendingBridgeTxsResponse = JsonRpcResponse<string>;
@@ -372,6 +378,10 @@ export type RPCRequestAndResponses = {
   get_payment_channels_by_ledger: [
     GetPaymentChannelsByLedgerRequest,
     GetPaymentChannelsByLedgerResponse
+  ];
+  get_swap_channels_by_ledger: [
+    GetSwapChannelsByLedgerRequest,
+    GetSwapChannelsByLedgerResponse
   ];
   get_objective: [GetObjectiveRequest, GetObjectiveResponse];
   get_l2_objective_from_l1: [

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -328,7 +328,9 @@ export type GetSignedStateResponse = JsonRpcResponse<string>;
 export type GetPaymentChannelsByLedgerResponse = JsonRpcResponse<
   PaymentChannelInfo[]
 >;
-export type GetSwapChannelsByLedgerResponse = JsonRpcResponse<string>;
+export type GetSwapChannelsByLedgerResponse = JsonRpcResponse<
+  SwapChannelInfo[]
+>;
 export type GetObjectiveResponse = JsonRpcResponse<string>;
 export type GetL2ObjectiveFromL1Response = JsonRpcResponse<string>;
 export type GetPendingBridgeTxsResponse = JsonRpcResponse<string>;

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -251,6 +251,7 @@ func (o *Objective) Reject() (protocols.Objective, protocols.SideEffects) {
 
 	updated.Status = protocols.Rejected
 	peer := o.C.Participants[1-o.C.MyIndex]
+	updated.C.OnChain.ChannelMode = channel.Finalized
 
 	sideEffects := protocols.SideEffects{MessagesToSend: protocols.CreateRejectionNoticeMessage(o.Id(), peer)}
 	return &updated, sideEffects

--- a/protocols/swapfund/swapfund.go
+++ b/protocols/swapfund/swapfund.go
@@ -619,12 +619,12 @@ func ConstructObjectiveFromPayload(
 
 				leftC, ok = getTwoPartyConsensusLedger(leftOfMe)
 				if !ok {
-					return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", leftOfMe, myAddress)
+					return Objective{}, fmt.Errorf("%w between %v and %v", types.ErrLeftLedgerChannelNotFound, leftOfMe, myAddress)
 				}
 
 				rightC, ok = getTwoPartyConsensusLedger(rightOfMe)
 				if !ok {
-					return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", myAddress, rightOfMe)
+					return Objective{}, fmt.Errorf("%w between %v and %v", types.ErrRightLedgerChannelNotFound, myAddress, rightOfMe)
 				}
 
 				break

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -630,12 +630,12 @@ func ConstructObjectiveFromPayload(
 
 				leftC, ok = getTwoPartyConsensusLedger(leftOfMe)
 				if !ok {
-					return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", leftOfMe, myAddress)
+					return Objective{}, fmt.Errorf("%w between %v and %v", types.ErrLeftLedgerChannelNotFound, leftOfMe, myAddress)
 				}
 
 				rightC, ok = getTwoPartyConsensusLedger(rightOfMe)
 				if !ok {
-					return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", myAddress, rightOfMe)
+					return Objective{}, fmt.Errorf("%w between %v and %v", types.ErrRightLedgerChannelNotFound, myAddress, rightOfMe)
 				}
 
 				break

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -263,6 +263,23 @@ func (nrs *NodeRpcServer) registerHandlers() (err error) {
 				}
 				return nrs.node.GetPaymentChannelsByLedger(req.LedgerId)
 			})
+		case serde.GetSwapChannelsByLedgerMethod:
+			return processRequest(nrs.BaseRpcServer, permRead, requestData, func(req serde.GetSwapChannelsByLedgerRequest) (string, error) {
+				if err := serde.ValidateGetSwapChannelsByLedgerRequest(req); err != nil {
+					return "", err
+				}
+				info, err := nrs.node.GetSwapChannelsByLedger(req.LedgerId)
+				if err != nil {
+					return "", err
+				}
+
+				marshalledSwapChannelInfo, err := json.Marshal(info)
+				if err != nil {
+					return "", err
+				}
+
+				return string(marshalledSwapChannelInfo), nil
+			})
 		case serde.GetVoucherRequestMethod:
 			return processRequest(nrs.BaseRpcServer, permRead, requestData, func(req serde.GetVoucherRequest) (payments.Voucher, error) {
 				return nrs.node.GetVoucher(req.Id), nil

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -38,6 +38,7 @@ const (
 	GetVoucherRequestMethod           RequestMethod = "get_voucher"
 	GetLedgerChannelRequestMethod     RequestMethod = "get_ledger_channel"
 	GetPaymentChannelsByLedgerMethod  RequestMethod = "get_payment_channels_by_ledger"
+	GetSwapChannelsByLedgerMethod     RequestMethod = "get_swap_channels_by_ledger"
 	GetAllLedgerChannelsMethod        RequestMethod = "get_all_ledger_channels"
 	GetNodeInfoRequestMethod          RequestMethod = "get_node_info"
 	GetPendingSwapRequestMethod       RequestMethod = "get_pending_swap"
@@ -131,6 +132,10 @@ type GetPaymentChannelsByLedgerRequest struct {
 	LedgerId types.Destination
 }
 
+type GetSwapChannelsByLedgerRequest struct {
+	LedgerId types.Destination
+}
+
 type ValidateVoucherRequest struct {
 	VoucherHash common.Hash
 	Signer      common.Address
@@ -181,6 +186,7 @@ type RequestPayload interface {
 		GetPaymentChannelRequest |
 		GetSwapChannelRequest |
 		GetPaymentChannelsByLedgerRequest |
+		GetSwapChannelsByLedgerRequest |
 		GetSignedStateRequest |
 		GetVoucherRequest |
 		NoPayloadRequest |

--- a/rpc/serde/validation.go
+++ b/rpc/serde/validation.go
@@ -42,6 +42,13 @@ func ValidateGetPaymentChannelsByLedgerRequest(req GetPaymentChannelsByLedgerReq
 	return nil
 }
 
+func ValidateGetSwapChannelsByLedgerRequest(req GetSwapChannelsByLedgerRequest) error {
+	if (req.LedgerId == types.Destination{}) {
+		return InvalidParamsError
+	}
+	return nil
+}
+
 func ValidateGetSignedStateRequest(req GetSignedStateRequest) error {
 	if (req.Id == types.Destination{}) {
 		return InvalidParamsError

--- a/types/types.go
+++ b/types/types.go
@@ -2,6 +2,7 @@
 package types // import "github.com/statechannels/go-nitro/types"
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -69,4 +70,9 @@ const (
 	Ledger ChannelType = iota
 	Virtual
 	Swap
+)
+
+var (
+	ErrLeftLedgerChannelNotFound  error = errors.New("could not left ledger channel")
+	ErrRightLedgerChannelNotFound error = errors.New("could not right ledger channel")
 )

--- a/types/types.go
+++ b/types/types.go
@@ -73,6 +73,6 @@ const (
 )
 
 var (
-	ErrLeftLedgerChannelNotFound  error = errors.New("could not left ledger channel")
-	ErrRightLedgerChannelNotFound error = errors.New("could not right ledger channel")
+	ErrLeftLedgerChannelNotFound  error = errors.New("could not find left ledger channel")
+	ErrRightLedgerChannelNotFound error = errors.New("could not find right ledger channel")
 )


### PR DESCRIPTION
Part of [Swap channels in go-nitro](https://www.notion.so/Swap-channels-in-go-nitro-119a6b22d47280b9bcf4e339fa6ba5b4)
- Handle intermediary panic if virtualfund / swapfund is initiated with incorrect counter party address
- Use policy maker to prevent ledger channel creation from L2 node with Bridge
- Add CLI to get all swap channels by ledger channel