### PR TITLE
Update nitro-rpc-client package version to `0.1.6`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,9 @@ jobs:
         run: |
           cd ./packages/nitro-protocol
           npm publish
+        continue-on-error: true
       - name: Publish nitro-rpc-client package
         run: |
           cd ./packages/nitro-rpc-client
           npm publish
+        continue-on-error: true

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -226,9 +226,11 @@ func (e *Engine) run(ctx context.Context) {
 		var err error
 
 		var blockTicker <-chan time.Time
+		var ticker *time.Ticker
 		_, isEthChainService := e.chain.(*chainservice.EthChainService)
 		if isEthChainService {
-			blockTicker = time.NewTicker(5 * time.Second).C
+			ticker = time.NewTicker(5 * time.Second)
+			blockTicker = ticker.C
 		}
 
 		select {
@@ -275,6 +277,10 @@ func (e *Engine) run(ctx context.Context) {
 				err = e.processStoreChannels(chainServiceBlock)
 			}
 		case <-ctx.Done():
+			if ticker != nil {
+				ticker.Stop()
+			}
+
 			e.wg.Done()
 			return
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -502,16 +502,16 @@ func (n *Node) Close() error {
 	if err := n.engine.Close(); err != nil {
 		return err
 	}
-	slog.Debug("DEBUG: node.go-close closed engine")
+	slog.Debug("DEBUG: node.go-close closed engine", "nodeAddress", n.Address.String())
 	if err := n.channelNotifier.Close(); err != nil {
 		return err
 	}
-	slog.Debug("DEBUG: node.go-close closed channelNotifier")
+	slog.Debug("DEBUG: node.go-close closed channelNotifier", "nodeAddress", n.Address.String())
 
 	if err := n.completedObjectivesNotifier.Close(); err != nil {
 		return err
 	}
-	slog.Debug("DEBUG: node.go-close closed completedObjectivesNotifier")
+	slog.Debug("DEBUG: node.go-close closed completedObjectivesNotifier", "nodeAddress", n.Address.String())
 
 	return n.store.Close()
 }

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -74,6 +74,9 @@ func TestChallenge(t *testing.T) {
 		t.Log(err)
 	}
 
+	chA := nodeA.ObjectiveCompleteChan(response)
+	chB := nodeB.ObjectiveCompleteChan(response)
+
 	// Wait for Bob's objective to be in challenge mode
 	time.Sleep(5 * time.Second)
 	objectiveA, _ := storeA.GetObjectiveByChannelId(ledgerChannel)
@@ -85,8 +88,6 @@ func TestChallenge(t *testing.T) {
 	testhelpers.Assert(t, objB.C.OnChain.ChannelMode == channel.Challenge, "Expected channel status to be challenge")
 
 	// Wait for objectives to complete
-	chA := nodeA.ObjectiveCompleteChan(response)
-	chB := nodeB.ObjectiveCompleteChan(response)
 	<-chA
 	<-chB
 

--- a/node_test/integration_test.go
+++ b/node_test/integration_test.go
@@ -191,6 +191,13 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 
 		t.Log("DEBUG: After checking payment channels")
 
+		var objCompleteChannels []<-chan protocols.ObjectiveId
+		objCompleteChannels = append(objCompleteChannels, clientA.CompletedObjectives(), clientB.CompletedObjectives())
+
+		for _, i := range intermediaries {
+			objCompleteChannels = append(objCompleteChannels, i.CompletedObjectives())
+		}
+
 		// Close virtual channels
 		closeVirtualIds := make([]protocols.ObjectiveId, len(virtualIds))
 		for i := 0; i < len(virtualIds); i++ {
@@ -209,7 +216,11 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 			}
 		}
 
-		waitForObjectives(t, clientA, clientB, intermediaries, closeVirtualIds)
+		for _, c := range objCompleteChannels {
+			for range virtualIds {
+				<-c
+			}
+		}
 
 		t.Log("DEBUG: After closing virtual channels")
 

--- a/node_test/swap_test.go
+++ b/node_test/swap_test.go
@@ -388,9 +388,9 @@ func TestParallelSwaps(t *testing.T) {
 		}
 
 		swapInfoFromNodeA := <-nodeASwapUpdates
-		t.Log("Received swap info from node A")
+		t.Log("Received swap info from node A", swapInfoFromNodeA.Id)
 		swapInfoFromNodeB := <-nodeBSwapUpdates
-		t.Log("Received swap info from node B")
+		t.Log("Received swap info from node B", swapInfoFromNodeB.Id)
 
 		// Wait for swap channel leader (node A) to make a decision (Which swap to accept and which one to reject)
 		// The rejected objective will be completed

--- a/node_test/swap_test.go
+++ b/node_test/swap_test.go
@@ -93,19 +93,19 @@ func initializeNodesAndInfra(t *testing.T) (TestUtils, func()) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Log("DEBUG: Closed node B")
+		t.Log("DEBUG: Closed node B", nodeB.Address.String())
 
 		err = nodeC.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Log("DEBUG: Closed node C")
+		t.Log("DEBUG: Closed node C", nodeC.Address.String())
 
 		err = nodeA.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Log("DEBUG: Closed node A")
+		t.Log("DEBUG: Closed node A", nodeA.Address.String())
 
 		infra.Close(t)
 		t.Log("DEBUG: Closed infra")

--- a/packages/nitro-rpc-client/package.json
+++ b/packages/nitro-rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/nitro-rpc-client",
-  "version": "0.0.9",
+  "version": "0.1.6",
   "description": "Typescript RPC client for go-nitro",
   "repository": "https://github.com/statechannels/nitro-rpc-client.git",
   "license": "MIT",


### PR DESCRIPTION
Part of [Swap channels in go-nitro](https://www.notion.so/Swap-channels-in-go-nitro-119a6b22d47280b9bcf4e339fa6ba5b4)
- Skip CI publish error if package version is not upgraded