### PR TITLE
Remove swap notifications in RPC server

### DIFF
--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -1534,7 +1534,7 @@ func (e *Engine) rejectSwapIfPendingExists(currentSwapObjective *swap.Objective)
 		return nil, err
 	}
 
-	slog.Debug("DEBUG: engine.go-rejectObjective", "pendingHash", currentHash.String(), "myIndex", swapChannel.MyIndex)
+	slog.Debug("DEBUG: engine.go-rejectObjective", "pendingHash", pendingHash.String(), "myIndex", swapChannel.MyIndex)
 
 	// Do not enter if pending swap and current swap are same and this node is not the swap channel leader
 	if pendingSwap != nil && strings.Compare(pendingHash.String(), currentHash.String()) != 0 && swapChannel.MyIndex == 0 {

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -75,9 +75,8 @@ func NewNodeRpcServer(nitroNode *nitro.Node, paymentManager paymentsmanager.Paym
 	completedObjChan := nrs.node.CompletedObjectives()
 	ledgerUpdateChan := nrs.node.LedgerUpdates()
 	paymentUpdateChan := nrs.node.PaymentUpdates()
-	swapUpdateChan := nrs.node.SwapUpdates()
 
-	go nrs.sendNotifications(ctx, completedObjChan, ledgerUpdateChan, paymentUpdateChan, swapUpdateChan)
+	go nrs.sendNotifications(ctx, completedObjChan, ledgerUpdateChan, paymentUpdateChan)
 
 	err := nrs.registerHandlers()
 	if err != nil {
@@ -354,7 +353,6 @@ func (rs *NodeRpcServer) sendNotifications(ctx context.Context,
 	completedObjChan <-chan protocols.ObjectiveId,
 	ledgerUpdatesChan <-chan query.LedgerChannelInfo,
 	paymentUpdatesChan <-chan query.PaymentChannelInfo,
-	swapUpdatesChan <-chan query.SwapInfo,
 ) {
 	defer rs.wg.Done()
 	for {
@@ -388,16 +386,6 @@ func (rs *NodeRpcServer) sendNotifications(ctx context.Context,
 
 			slog.Debug("DEBUG: node_server.go-sendNotifications sending payment_channel_updated notification")
 			err := sendNotification(rs.BaseRpcServer, serde.PaymentChannelUpdated, paymentInfo)
-			if err != nil {
-				panic(err)
-			}
-		case swapInfo, ok := <-swapUpdatesChan:
-			if !ok {
-				rs.logger.Warn("SwapUpdates channel closed, exiting sendNotifications")
-				return
-			}
-
-			err := sendNotification(rs.BaseRpcServer, serde.SwapUpdated, swapInfo)
 			if err != nil {
 				panic(err)
 			}

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -68,7 +68,6 @@ const (
 	LedgerChannelUpdated  NotificationMethod = "ledger_channel_updated"
 	PaymentChannelUpdated NotificationMethod = "payment_channel_updated"
 	MirrorChannelCreated  NotificationMethod = "mirror_channel_created"
-	SwapUpdated           NotificationMethod = "swap_updated"
 )
 
 type NotificationOrRequest interface {


### PR DESCRIPTION
Part of [Swap channels in go-nitro](https://www.notion.so/Swap-channels-in-go-nitro-119a6b22d47280b9bcf4e339fa6ba5b4)